### PR TITLE
Add campaign analytics dashboard layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,375 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Campaign Analytics Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Material+Symbols+Outlined:wght@400&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="dashboard">
+      <aside class="sidebar">
+        <div class="sidebar__brand">
+          <div class="logo">C</div>
+          <div>
+            <p class="brand-title">Campaigns</p>
+            <span class="brand-subtitle">Management</span>
+          </div>
+        </div>
+        <button class="sidebar__create">
+          <span class="material-symbols-outlined"> add_circle </span>
+          New Campaign
+        </button>
+        <nav class="sidebar__menu">
+          <p class="sidebar__section">Menu</p>
+          <a class="active" href="#">
+            <span class="material-symbols-outlined"> dashboard </span>
+            Dashboard
+          </a>
+          <a href="#">
+            <span class="material-symbols-outlined"> play_circle </span>
+            Campaigns
+          </a>
+          <a href="#">
+            <span class="material-symbols-outlined"> groups </span>
+            Influencers
+          </a>
+          <a href="#">
+            <span class="material-symbols-outlined"> bar_chart </span>
+            Analytics
+          </a>
+          <a href="#">
+            <span class="material-symbols-outlined"> folder_open </span>
+            Library
+          </a>
+        </nav>
+        <div class="sidebar__menu">
+          <p class="sidebar__section">Teams</p>
+          <a href="#">
+            <span class="status status--blue"></span>
+            Blue Chips
+          </a>
+          <a href="#">
+            <span class="status status--green"></span>
+            Retail Boosters
+          </a>
+          <a href="#">
+            <span class="status status--purple"></span>
+            Growth Labs
+          </a>
+        </div>
+        <div class="sidebar__upgrade">
+          <p>Become Pro Access</p>
+          <span>Unlock advanced analytics</span>
+          <button>Upgrade now</button>
+        </div>
+      </aside>
+      <main class="content">
+        <header class="topbar">
+          <div class="topbar__left">
+            <div class="campaign-chip">Blue Chips Chicago</div>
+            <div class="platform-tabs">
+              <button class="active">TikTok</button>
+              <button>Instagram</button>
+              <button>Youtube</button>
+            </div>
+          </div>
+          <div class="topbar__right">
+            <div class="search">
+              <span class="material-symbols-outlined"> search </span>
+              <input type="text" placeholder="Search something..." />
+            </div>
+            <button class="icon-button">
+              <span class="material-symbols-outlined"> notifications </span>
+            </button>
+            <button class="icon-button">
+              <span class="material-symbols-outlined"> settings </span>
+            </button>
+            <div class="user-card">
+              <div class="user-avatar">JY</div>
+              <div>
+                <p class="user-name">Jony Inc</p>
+                <span class="user-role">Creator</span>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section class="grid">
+          <article class="card card--main">
+            <div class="card__header">
+              <div>
+                <p class="muted">Total Reach</p>
+                <h1>350,809</h1>
+              </div>
+              <div class="trend trend--positive">
+                <span class="material-symbols-outlined"> arrow_upward </span>
+                <span>8.7%</span>
+              </div>
+            </div>
+            <div class="highlights">
+              <div>
+                <p class="muted">Likes</p>
+                <h3>186,072</h3>
+              </div>
+              <div>
+                <p class="muted">Comments</p>
+                <h3>12,043</h3>
+              </div>
+              <div>
+                <p class="muted">Shares</p>
+                <h3>48,072</h3>
+              </div>
+            </div>
+            <div class="conversion">
+              <p>Conversion Rate</p>
+              <div class="progress">
+                <div class="progress__value" style="width: 68%"></div>
+              </div>
+              <span class="progress__label">68% goal completion</span>
+            </div>
+            <div class="sentiment">
+              <div class="sentiment__item">
+                <span class="dot dot--green"></span>
+                <div>
+                  <p class="muted">Positive</p>
+                  <strong>72%</strong>
+                </div>
+              </div>
+              <div class="sentiment__item">
+                <span class="dot dot--yellow"></span>
+                <div>
+                  <p class="muted">Neutral</p>
+                  <strong>18%</strong>
+                </div>
+              </div>
+              <div class="sentiment__item">
+                <span class="dot dot--red"></span>
+                <div>
+                  <p class="muted">Negative</p>
+                  <strong>10%</strong>
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <article class="card card--compact">
+            <div class="card__header">
+              <div>
+                <p class="muted">Campaign Reach</p>
+                <h2>180,807,893</h2>
+              </div>
+            </div>
+            <ul class="campaign-details">
+              <li>
+                <span>12 countries</span>
+                <span>reach</span>
+              </li>
+              <li>
+                <span>90 creators</span>
+                <span>active</span>
+              </li>
+              <li>
+                <span>3 months</span>
+                <span>duration</span>
+              </li>
+            </ul>
+            <div class="mini-chart">
+              <div class="bar" style="height: 36%"></div>
+              <div class="bar" style="height: 62%"></div>
+              <div class="bar" style="height: 80%"></div>
+              <div class="bar" style="height: 52%"></div>
+              <div class="bar" style="height: 68%"></div>
+              <div class="bar" style="height: 92%"></div>
+            </div>
+          </article>
+
+          <article class="card card--map">
+            <div class="card__header">
+              <div>
+                <p class="muted">Top Performing Regions</p>
+                <h2>Global Coverage</h2>
+              </div>
+              <button class="icon-button">
+                <span class="material-symbols-outlined"> more_horiz </span>
+              </button>
+            </div>
+            <div class="map">
+              <div class="map__bubble" style="top: 35%; left: 24%">
+                <span>Chicago</span>
+                <strong>54k</strong>
+              </div>
+              <div class="map__bubble" style="top: 28%; left: 60%">
+                <span>Berlin</span>
+                <strong>38k</strong>
+              </div>
+              <div class="map__bubble" style="top: 68%; left: 76%">
+                <span>Singapore</span>
+                <strong>32k</strong>
+              </div>
+            </div>
+          </article>
+
+          <article class="card card--table">
+            <div class="card__header">
+              <div>
+                <p class="muted">Top Influencers</p>
+                <h2>Influencer Roster</h2>
+              </div>
+              <button class="icon-button">
+                <span class="material-symbols-outlined"> upload_file </span>
+              </button>
+            </div>
+            <table>
+              <thead>
+                <tr>
+                  <th>Influencer</th>
+                  <th>Posts</th>
+                  <th>Followers</th>
+                  <th>Engagement</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    <span class="avatar avatar--pink">MW</span>
+                    Malik Winocott
+                  </td>
+                  <td>24</td>
+                  <td>1.2M</td>
+                  <td>
+                    <span class="trend trend--positive">
+                      <span class="material-symbols-outlined"> arrow_upward </span>
+                      12%
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span class="avatar avatar--purple">DA</span>
+                    Daphne Alden
+                  </td>
+                  <td>19</td>
+                  <td>864K</td>
+                  <td>
+                    <span class="trend trend--neutral">
+                      <span class="material-symbols-outlined"> horizontal_rule </span>
+                      0.2%
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span class="avatar avatar--cyan">LS</span>
+                    Lysa Sanchez
+                  </td>
+                  <td>16</td>
+                  <td>640K</td>
+                  <td>
+                    <span class="trend trend--negative">
+                      <span class="material-symbols-outlined"> arrow_downward </span>
+                      -3%
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <span class="avatar avatar--orange">TN</span>
+                    Theo Nanda
+                  </td>
+                  <td>21</td>
+                  <td>712K</td>
+                  <td>
+                    <span class="trend trend--positive">
+                      <span class="material-symbols-outlined"> arrow_upward </span>
+                      6%
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </article>
+
+          <article class="card card--audience">
+            <div class="card__header">
+              <div>
+                <p class="muted">Audience Age Gender</p>
+                <h2>Distribution</h2>
+              </div>
+            </div>
+            <div class="bars">
+              <div class="bar-row">
+                <span>18-24</span>
+                <div class="bar-track">
+                  <div class="bar-track__segment female" style="width: 62%"></div>
+                  <div class="bar-track__segment male" style="width: 38%"></div>
+                </div>
+                <span>62%</span>
+              </div>
+              <div class="bar-row">
+                <span>25-34</span>
+                <div class="bar-track">
+                  <div class="bar-track__segment female" style="width: 48%"></div>
+                  <div class="bar-track__segment male" style="width: 52%"></div>
+                </div>
+                <span>48%</span>
+              </div>
+              <div class="bar-row">
+                <span>35-44</span>
+                <div class="bar-track">
+                  <div class="bar-track__segment female" style="width: 36%"></div>
+                  <div class="bar-track__segment male" style="width: 64%"></div>
+                </div>
+                <span>36%</span>
+              </div>
+              <div class="bar-row">
+                <span>45-54</span>
+                <div class="bar-track">
+                  <div class="bar-track__segment female" style="width: 22%"></div>
+                  <div class="bar-track__segment male" style="width: 78%"></div>
+                </div>
+                <span>22%</span>
+              </div>
+            </div>
+            <div class="legend">
+              <div><span class="dot dot--blue"></span>Male</div>
+              <div><span class="dot dot--pink"></span>Female</div>
+            </div>
+          </article>
+
+          <article class="card card--radar">
+            <div class="card__header">
+              <div>
+                <p class="muted">Follower Interests</p>
+                <h2>Affinity Radar</h2>
+              </div>
+            </div>
+            <div class="radar">
+              <svg viewBox="0 0 200 200" role="img" aria-label="Radar chart">
+                <polygon class="radar-grid" points="100,10 190,100 100,190 10,100" />
+                <polygon class="radar-grid" points="100,40 160,100 100,160 40,100" />
+                <polygon class="radar-grid" points="100,70 130,100 100,130 70,100" />
+                <polygon
+                  class="radar-shape"
+                  points="100,35 155,105 105,150 45,90"
+                />
+              </svg>
+              <ul>
+                <li><span class="dot dot--orange"></span>Fashion</li>
+                <li><span class="dot dot--cyan"></span>Beauty</li>
+                <li><span class="dot dot--purple"></span>Tech</li>
+                <li><span class="dot dot--green"></span>Gaming</li>
+              </ul>
+            </div>
+          </article>
+        </section>
+      </main>
+    </div>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,757 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fb;
+  --card-bg: #ffffff;
+  --muted: #7a8699;
+  --border: #e5e8f0;
+  --primary: #2563eb;
+  --primary-soft: rgba(37, 99, 235, 0.08);
+  --positive: #16a34a;
+  --negative: #dc2626;
+  --neutral: #f59e0b;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: #eef1f7;
+}
+
+.dashboard {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: #ffffff;
+  border-right: 1px solid var(--border);
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.sidebar__brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+}
+
+.brand-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.brand-subtitle {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.sidebar__create {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.2);
+}
+
+.sidebar__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sidebar__menu a {
+  text-decoration: none;
+  color: inherit;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border-radius: 12px;
+  font-weight: 500;
+  transition: background 0.2s, color 0.2s;
+}
+
+.sidebar__menu a:hover,
+.sidebar__menu a.active {
+  background: var(--primary-soft);
+  color: var(--primary);
+}
+
+.sidebar__section {
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+  margin: 8px 0 0;
+}
+
+.status {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.status--blue {
+  background: #2563eb;
+}
+
+.status--green {
+  background: #22c55e;
+}
+
+.status--purple {
+  background: #7c3aed;
+}
+
+.sidebar__upgrade {
+  margin-top: auto;
+  background: linear-gradient(135deg, #2563eb, #7c3aed);
+  color: #fff;
+  padding: 20px;
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  text-align: left;
+  box-shadow: 0 18px 35px rgba(124, 58, 237, 0.25);
+}
+
+.sidebar__upgrade p {
+  margin: 0;
+  font-weight: 600;
+  font-size: 18px;
+}
+
+.sidebar__upgrade span {
+  font-size: 14px;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.sidebar__upgrade button {
+  background: #fff;
+  color: #1f2933;
+  border: none;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.content {
+  padding: 32px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.topbar__left {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+
+.campaign-chip {
+  background: #fff;
+  border-radius: 999px;
+  padding: 10px 20px;
+  font-weight: 600;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.05);
+}
+
+.platform-tabs {
+  background: #fff;
+  border-radius: 999px;
+  padding: 6px;
+  display: flex;
+  gap: 4px;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.05);
+}
+
+.platform-tabs button {
+  border: none;
+  background: transparent;
+  padding: 8px 16px;
+  border-radius: 999px;
+  font-weight: 500;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.platform-tabs button.active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.topbar__right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.search {
+  background: #fff;
+  border-radius: 999px;
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 240px;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.search input {
+  border: none;
+  outline: none;
+  flex: 1;
+  font-size: 14px;
+}
+
+.icon-button {
+  border: none;
+  background: #fff;
+  border-radius: 12px;
+  width: 44px;
+  height: 44px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+  color: var(--muted);
+}
+
+.user-card {
+  background: #fff;
+  padding: 6px 14px 6px 6px;
+  border-radius: 999px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+}
+
+.user-avatar {
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: #fff;
+  font-weight: 600;
+}
+
+.user-name {
+  margin: 0;
+  font-weight: 600;
+}
+
+.user-role {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 24px;
+}
+
+.card {
+  background: var(--card-bg);
+  border-radius: 24px;
+  padding: 24px;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.card__header h1,
+.card__header h2,
+.card__header h3 {
+  margin: 4px 0 0;
+  line-height: 1;
+}
+
+.card__header p {
+  margin: 0;
+}
+
+.card--main {
+  grid-column: span 3;
+}
+
+.card--compact {
+  grid-column: span 2;
+}
+
+.card--map {
+  grid-column: span 1;
+}
+
+.card--table {
+  grid-column: span 3;
+}
+
+.card--audience {
+  grid-column: span 2;
+}
+
+.card--radar {
+  grid-column: span 1;
+}
+
+.muted {
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.trend {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.trend--positive {
+  color: var(--positive);
+  background: rgba(22, 163, 74, 0.12);
+}
+
+.trend--negative {
+  color: var(--negative);
+  background: rgba(220, 38, 38, 0.12);
+}
+
+.trend--neutral {
+  color: #0f172a;
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.highlights {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.highlights h3 {
+  margin: 6px 0 0;
+  font-size: 22px;
+}
+
+.conversion p {
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.progress {
+  height: 12px;
+  background: #eef1f7;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress__value {
+  height: 100%;
+  background: linear-gradient(90deg, #2563eb, #38bdf8);
+  border-radius: 999px;
+}
+
+.progress__label {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.sentiment {
+  display: flex;
+  gap: 16px;
+}
+
+.sentiment__item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: #f8fafc;
+}
+
+.dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.dot--green {
+  background: #22c55e;
+}
+
+.dot--yellow {
+  background: #facc15;
+}
+
+.dot--red {
+  background: #ef4444;
+}
+
+.dot--blue {
+  background: #2563eb;
+}
+
+.dot--pink {
+  background: #ec4899;
+}
+
+.dot--cyan {
+  background: #06b6d4;
+}
+
+.dot--orange {
+  background: #f97316;
+}
+
+.dot--purple {
+  background: #8b5cf6;
+}
+
+.campaign-details {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.campaign-details li {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+  background: #f8fafc;
+  padding: 10px 12px;
+  border-radius: 12px;
+  color: #1f2937;
+}
+
+.mini-chart {
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 8px;
+  align-items: end;
+  height: 120px;
+}
+
+.mini-chart .bar {
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.2), rgba(37, 99, 235, 0.65));
+  border-radius: 6px 6px 2px 2px;
+}
+
+.map {
+  position: relative;
+  flex: 1;
+  border-radius: 16px;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.25), transparent 50%),
+    radial-gradient(circle at 80% 40%, rgba(37, 99, 235, 0.2), transparent 55%),
+    #f1f5f9;
+  overflow: hidden;
+}
+
+.map::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: url('https://upload.wikimedia.org/wikipedia/commons/8/80/World_map_-_low_resolution.svg')
+    center/cover no-repeat;
+  opacity: 0.2;
+}
+
+.map__bubble {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  background: #fff;
+  padding: 10px 14px;
+  border-radius: 14px;
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.map__bubble strong {
+  font-size: 16px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 14px;
+}
+
+thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 600;
+  padding-bottom: 12px;
+}
+
+tbody td {
+  padding: 10px 0;
+  border-top: 1px solid var(--border);
+}
+
+tbody tr:first-child td {
+  border-top: none;
+}
+
+.avatar {
+  width: 34px;
+  height: 34px;
+  border-radius: 10px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #fff;
+  font-weight: 600;
+  margin-right: 12px;
+}
+
+.avatar--pink {
+  background: linear-gradient(135deg, #ec4899, #f97316);
+}
+
+.avatar--purple {
+  background: linear-gradient(135deg, #8b5cf6, #6366f1);
+}
+
+.avatar--cyan {
+  background: linear-gradient(135deg, #06b6d4, #3b82f6);
+}
+
+.avatar--orange {
+  background: linear-gradient(135deg, #f97316, #facc15);
+}
+
+.card--table .trend {
+  font-size: 13px;
+}
+
+.card--audience .bars {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.bar-row {
+  display: grid;
+  grid-template-columns: 70px 1fr 50px;
+  align-items: center;
+  gap: 12px;
+  font-weight: 500;
+}
+
+.bar-track {
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  display: flex;
+  background: #e2e8f0;
+}
+
+.bar-track__segment {
+  height: 100%;
+}
+
+.bar-track__segment.female {
+  background: rgba(236, 72, 153, 0.6);
+}
+
+.bar-track__segment.male {
+  background: rgba(37, 99, 235, 0.6);
+}
+
+.legend {
+  display: flex;
+  gap: 16px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.radar {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.radar svg {
+  width: 140px;
+  height: 140px;
+}
+
+.radar-grid {
+  fill: none;
+  stroke: rgba(148, 163, 184, 0.3);
+  stroke-width: 1;
+}
+
+.radar-shape {
+  fill: rgba(37, 99, 235, 0.15);
+  stroke: rgba(37, 99, 235, 0.6);
+  stroke-width: 2;
+}
+
+.radar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--muted);
+}
+
+.material-symbols-outlined {
+  font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+  font-size: 20px;
+}
+
+@media (max-width: 1280px) {
+  .dashboard {
+    grid-template-columns: 220px 1fr;
+  }
+
+  .grid {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  .card--main {
+    grid-column: span 4;
+  }
+
+  .card--compact {
+    grid-column: span 2;
+  }
+
+  .card--map {
+    grid-column: span 2;
+  }
+
+  .card--table {
+    grid-column: span 4;
+  }
+
+  .card--audience {
+    grid-column: span 2;
+  }
+
+  .card--radar {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 960px) {
+  .dashboard {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .content {
+    padding: 24px;
+  }
+
+  .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .card--main,
+  .card--table {
+    grid-column: span 2;
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .topbar__right {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .content {
+    padding: 16px;
+  }
+
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card--main,
+  .card--compact,
+  .card--map,
+  .card--table,
+  .card--audience,
+  .card--radar {
+    grid-column: span 1;
+  }
+
+  .search {
+    min-width: unset;
+    width: 100%;
+  }
+
+  .sentiment {
+    flex-direction: column;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static campaign analytics dashboard page with sidebar navigation, metrics cards, and charts
- create a comprehensive stylesheet that mirrors the provided design and adds responsive behavior

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68cbb7da5cfc83289917aae7d1ef5566