### PR TITLE
Update timeframe filter to show Sheet label

### DIFF
--- a/src/data/dashboardData.js
+++ b/src/data/dashboardData.js
@@ -14,12 +14,7 @@ const BASE_TOTALS = {
   title: 'Total earning',
 };
 
-export const TIMEFRAME_OPTIONS = [
-  { id: 'TM', label: 'TM', name: 'This Month' },
-  { id: 'TR', label: 'TR', name: 'This Quarter' },
-  { id: 'TY', label: 'TY', name: 'This Year' },
-  { id: 'ALL', label: 'ALL', name: 'Lifetime' },
-];
+export const TIMEFRAME_OPTIONS = [{ id: 'TY', label: 'Sheet', name: 'Sheet' }];
 
 export const DASHBOARD_DATA = {
   TM: {


### PR DESCRIPTION
## Summary
- replace the timeframe options with a single entry so the UI only shows "Sheet"

## Testing
- npm install *(fails: 403 Forbidden fetching @vitejs/plugin-react)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe60fc378832888dd761b543b6055