### PR TITLE
Fix HTML escaping in sheet paste instructions

### DIFF
--- a/src/components/SheetModal.jsx
+++ b/src/components/SheetModal.jsx
@@ -1346,13 +1346,13 @@ const SheetModal = ({ open, onClose, rows }) => {
             </div>
             <div className="sheet-side-panel__body">
               <label className="sheet-side-panel__label" htmlFor="sheet-paste-textarea">
-                Paste one keyword per line, or two columns separated by comma/tab: primary<TAB>secondary.
+                Paste one keyword per line, or two columns separated by comma/tab: primary&lt;TAB&gt;secondary.
               </label>
               <textarea
                 id="sheet-paste-textarea"
                 value={pasteText}
                 onChange={(event) => setPasteText(event.target.value)}
-                placeholder="Paste one keyword per line, or two columns separated by comma/tab: primary<TAB>secondary."
+                placeholder="Paste one keyword per line, or two columns separated by comma/tab: primary&lt;TAB&gt;secondary."
               />
 
               <div className="sheet-side-panel__options">


### PR DESCRIPTION
## Summary
- escape the instructional TAB text in the sheet paste panel to avoid JSX parse errors

## Testing
- `npm run build` *(fails: `vite` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc0031f9c08328a3191d5fef00a4c0