### PR TITLE
Handle formatted numeric input when computing WS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/


### PR DESCRIPTION
## Summary
- accept formatted metric values (thousand separators, currency symbols) when normalising rows so WS calculations work for pasted data
- reuse the sanitised parsing when editing rows to keep WS scores up to date
- ignore build artifacts and dependencies in version control

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd4620ee0c8328a2bedb302027940b