### PR TITLE
Add funnel stages page with visualization

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,11 +4,13 @@ import OverviewCard from './components/OverviewCard.jsx';
 import PerformancePanel from './components/PerformancePanel.jsx';
 import TotalsPanel from './components/TotalsPanel.jsx';
 import SheetModal from './components/SheetModal.jsx';
+import FunnelStages from './components/FunnelStages.jsx';
 import { KEYWORD_SHEET_ROWS } from './data/keywordSheet.js';
 import { DASHBOARD_DATA, TIMEFRAME_OPTIONS } from './data/dashboardData.js';
 
 const App = () => {
   const [activeTimeframe, setActiveTimeframe] = useState('TY');
+  const [activePage, setActivePage] = useState('overview');
   const [isSheetOpen, setIsSheetOpen] = useState(false);
 
   const activeData = DASHBOARD_DATA[activeTimeframe];
@@ -18,6 +20,47 @@ const App = () => {
     return option ? option.name : '';
   }, [activeTimeframe]);
 
+  const pageMetadata = useMemo(
+    () => ({
+      overview: {
+        title: 'General statistics',
+        subtitle: `Total system load${activeTimeframeLabel ? ` · ${activeTimeframeLabel}` : ''}`,
+      },
+      funnel: {
+        title: 'Funnel Stages',
+        subtitle: 'Visualise how prospects move through your revenue funnel.',
+      },
+    }),
+    [activeTimeframeLabel]
+  );
+
+  const pages = [
+    { id: 'overview', label: 'Overview' },
+    { id: 'funnel', label: 'Funnel Stages' },
+  ];
+
+  const renderPage = () => {
+    if (activePage === 'funnel') {
+      return (
+        <main className="funnel-layout">
+          <FunnelStages
+            timeframeOptions={TIMEFRAME_OPTIONS}
+            activeTimeframe={activeTimeframe}
+            onTimeframeChange={setActiveTimeframe}
+          />
+        </main>
+      );
+    }
+
+    return (
+      <main className="dashboard-grid">
+        <OverviewCard data={activeData.overview} />
+        <PerformancePanel data={activeData.performance} />
+        <TotalsPanel data={activeData.totals} />
+      </main>
+    );
+  };
+
   return (
     <div className="app">
       <div className="background-blob background-blob--one" aria-hidden="true" />
@@ -25,26 +68,42 @@ const App = () => {
       <div className="app-shell">
         <header className="page-header">
           <div>
-            <h1>General statistics</h1>
-            <p>{`Total system load${activeTimeframeLabel ? ` · ${activeTimeframeLabel}` : ''}`}</p>
+            <h1>{pageMetadata[activePage].title}</h1>
+            <p>{pageMetadata[activePage].subtitle}</p>
+            <nav className="page-nav" aria-label="Dashboard sections">
+              {pages.map((page) => {
+                const isActive = page.id === activePage;
+                return (
+                  <button
+                    key={page.id}
+                    type="button"
+                    className={`page-nav__button${isActive ? ' page-nav__button--active' : ''}`}
+                    aria-pressed={isActive}
+                    onClick={() => setActivePage(page.id)}
+                  >
+                    {page.label}
+                  </button>
+                );
+              })}
+            </nav>
           </div>
           <div className="page-header__actions">
-            <button type="button" className="sheet-trigger" onClick={() => setIsSheetOpen(true)}>
-              Sheet
-            </button>
-            <TimeFilter
-              options={TIMEFRAME_OPTIONS}
-              activeId={activeTimeframe}
-              onSelect={setActiveTimeframe}
-            />
+            {activePage === 'overview' ? (
+              <>
+                <button type="button" className="sheet-trigger" onClick={() => setIsSheetOpen(true)}>
+                  Sheet
+                </button>
+                <TimeFilter
+                  options={TIMEFRAME_OPTIONS}
+                  activeId={activeTimeframe}
+                  onSelect={setActiveTimeframe}
+                />
+              </>
+            ) : null}
           </div>
         </header>
 
-        <main className="dashboard-grid">
-          <OverviewCard data={activeData.overview} />
-          <PerformancePanel data={activeData.performance} />
-          <TotalsPanel data={activeData.totals} />
-        </main>
+        {renderPage()}
       </div>
       <SheetModal open={isSheetOpen} onClose={() => setIsSheetOpen(false)} rows={KEYWORD_SHEET_ROWS} />
     </div>

--- a/src/components/FunnelStages.jsx
+++ b/src/components/FunnelStages.jsx
@@ -1,0 +1,168 @@
+import PropTypes from 'prop-types';
+import TimeFilter from './TimeFilter.jsx';
+
+const leftStages = [
+  {
+    label: 'Business',
+    value: '$23,987',
+    gradient: 'linear-gradient(90deg, rgba(104, 96, 255, 0.85), rgba(106, 190, 255, 0.85))',
+    shadow: 'rgba(96, 128, 255, 0.35)',
+  },
+  {
+    label: 'Presentation',
+    value: '$54,641',
+    gradient: 'linear-gradient(90deg, rgba(106, 111, 255, 0.85), rgba(123, 210, 255, 0.8))',
+    shadow: 'rgba(110, 149, 255, 0.35)',
+  },
+  {
+    label: 'Finance',
+    value: '$38,120',
+    gradient: 'linear-gradient(90deg, rgba(95, 124, 255, 0.85), rgba(142, 228, 255, 0.78))',
+    shadow: 'rgba(85, 144, 255, 0.3)',
+  },
+  {
+    label: 'Development',
+    value: '$33,870',
+    gradient: 'linear-gradient(90deg, rgba(89, 139, 255, 0.85), rgba(162, 236, 255, 0.75))',
+    shadow: 'rgba(74, 152, 255, 0.28)',
+  },
+];
+
+const rightStages = [
+  {
+    label: 'Investments',
+    value: '$76,644',
+    gradient: 'linear-gradient(90deg, rgba(255, 150, 134, 0.85), rgba(255, 206, 134, 0.85))',
+    shadow: 'rgba(255, 173, 134, 0.35)',
+  },
+  {
+    label: 'Startup',
+    value: '$5,752',
+    gradient: 'linear-gradient(90deg, rgba(255, 143, 171, 0.85), rgba(255, 207, 176, 0.85))',
+    shadow: 'rgba(255, 164, 178, 0.32)',
+  },
+  {
+    label: 'Outsourcing',
+    value: '$4,978',
+    gradient: 'linear-gradient(90deg, rgba(255, 137, 200, 0.85), rgba(255, 210, 214, 0.82))',
+    shadow: 'rgba(255, 162, 208, 0.32)',
+  },
+  {
+    label: 'Main projects',
+    value: '$98,642',
+    gradient: 'linear-gradient(90deg, rgba(255, 133, 147, 0.85), rgba(255, 192, 147, 0.85))',
+    shadow: 'rgba(255, 162, 147, 0.32)',
+  },
+];
+
+const quickStats = [
+  {
+    label: 'Prediction',
+    value: '875',
+    detail: '↑ 35%',
+    tone: 'positive',
+  },
+  {
+    label: 'Pulse',
+    value: '438',
+    detail: 'Stable',
+    tone: 'neutral',
+  },
+  {
+    label: 'Activity',
+    value: '438',
+    detail: '↓ 12%',
+    tone: 'negative',
+  },
+];
+
+const FunnelStages = ({ timeframeOptions, activeTimeframe, onTimeframeChange }) => {
+  const activeOption = timeframeOptions.find((option) => option.id === activeTimeframe);
+  const timeframeName = activeOption ? activeOption.name : 'Overview';
+  const timeframeLabel = activeOption ? activeOption.label : '';
+
+  return (
+    <section className="card funnel-card" aria-labelledby="funnel-title">
+      <header className="funnel-card__header">
+        <div className="funnel-card__header-block">
+          <span className="card__eyebrow">Timeline</span>
+          <TimeFilter options={timeframeOptions} activeId={activeTimeframe} onSelect={onTimeframeChange} />
+        </div>
+        <div className="funnel-card__header-meta" aria-live="polite">
+          <span className="funnel-card__meta-label">{timeframeName}</span>
+          <span className="funnel-card__meta-value">{timeframeLabel}</span>
+        </div>
+      </header>
+
+      <div className="funnel-card__body">
+        <div className="funnel-card__titles">
+          <h2 id="funnel-title" className="funnel-card__title">
+            Data visualisation
+          </h2>
+          <p className="funnel-card__subtitle">Track how each funnel stage contributes to your total sales.</p>
+        </div>
+
+        <div className="funnel-visualization">
+          <div className="funnel-column funnel-column--left">
+            {leftStages.map((stage) => (
+              <div
+                key={stage.label}
+                className="funnel-stage funnel-stage--left"
+                style={{ '--funnel-stage-gradient': stage.gradient, '--funnel-stage-shadow': stage.shadow }}
+              >
+                <span className="funnel-stage__label">{stage.label}</span>
+                <span className="funnel-stage__value">{stage.value}</span>
+                <span className="funnel-stage__flow" aria-hidden="true" />
+              </div>
+            ))}
+          </div>
+
+          <div className="funnel-center" aria-label="Total sales">
+            <div className="funnel-center__ring" aria-hidden="true" />
+            <span className="funnel-center__eyebrow">Total sales</span>
+            <span className="funnel-center__value">204</span>
+            <span className="funnel-center__amount">$73,870</span>
+          </div>
+
+          <div className="funnel-column funnel-column--right">
+            {rightStages.map((stage) => (
+              <div
+                key={stage.label}
+                className="funnel-stage funnel-stage--right"
+                style={{ '--funnel-stage-gradient': stage.gradient, '--funnel-stage-shadow': stage.shadow }}
+              >
+                <span className="funnel-stage__label">{stage.label}</span>
+                <span className="funnel-stage__value">{stage.value}</span>
+                <span className="funnel-stage__flow" aria-hidden="true" />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="funnel-metrics" aria-label="Key funnel metrics">
+          {quickStats.map((stat) => (
+            <div key={stat.label} className={`funnel-metric funnel-metric--${stat.tone}`}>
+              <span className="funnel-metric__label">{stat.label}</span>
+              <span className="funnel-metric__value">{stat.value}</span>
+              <span className="funnel-metric__detail">{stat.detail}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+FunnelStages.propTypes = {
+  timeframeOptions: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    })
+  ).isRequired,
+  activeTimeframe: PropTypes.string.isRequired,
+  onTimeframeChange: PropTypes.func.isRequired,
+};
+
+export default FunnelStages;

--- a/src/index.css
+++ b/src/index.css
@@ -100,6 +100,315 @@ body {
   color: var(--text-soft);
 }
 
+.page-nav {
+  margin-top: 1.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+  backdrop-filter: blur(10px);
+  box-shadow: 0 12px 28px rgba(107, 91, 255, 0.16);
+}
+
+.page-nav__button {
+  border: none;
+  background: transparent;
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.page-nav__button:hover,
+.page-nav__button:focus-visible {
+  color: var(--primary);
+  background: rgba(255, 255, 255, 0.85);
+  outline: none;
+}
+
+.page-nav__button--active {
+  background: white;
+  color: var(--primary);
+  box-shadow: 0 10px 22px rgba(107, 91, 255, 0.2);
+}
+
+.funnel-layout {
+  display: flex;
+  flex-direction: column;
+}
+
+.funnel-card {
+  padding: 2.4rem 2.7rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.funnel-card::before,
+.funnel-card::after {
+  content: '';
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(90px);
+  opacity: 0.45;
+  pointer-events: none;
+}
+
+.funnel-card::before {
+  width: 320px;
+  height: 320px;
+  top: -160px;
+  left: -60px;
+  background: rgba(132, 112, 255, 0.3);
+}
+
+.funnel-card::after {
+  width: 360px;
+  height: 360px;
+  bottom: -180px;
+  right: -80px;
+  background: rgba(255, 177, 190, 0.3);
+}
+
+.funnel-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.5rem;
+  margin-bottom: 2.4rem;
+}
+
+.funnel-card__header-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.funnel-card__header-meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.25rem;
+  padding: 0.8rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.75);
+  box-shadow: 0 12px 30px rgba(71, 85, 172, 0.18);
+  color: var(--text-soft);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.funnel-card__meta-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.72rem;
+  color: var(--text-muted);
+}
+
+.funnel-card__meta-value {
+  color: var(--text-strong);
+  font-size: 1.05rem;
+}
+
+.funnel-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
+}
+
+.funnel-card__titles {
+  text-align: center;
+}
+
+.funnel-card__title {
+  margin: 0;
+  font-size: clamp(2rem, 3.5vw, 2.8rem);
+  color: var(--text-strong);
+}
+
+.funnel-card__subtitle {
+  margin: 0.5rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.funnel-visualization {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: center;
+  gap: 2.5rem;
+}
+
+.funnel-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.4rem;
+  position: relative;
+  z-index: 1;
+}
+
+.funnel-column--left {
+  align-items: flex-end;
+}
+
+.funnel-column--right {
+  align-items: flex-start;
+}
+
+.funnel-stage {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.95rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 18px 40px var(--funnel-stage-shadow, rgba(107, 91, 255, 0.18));
+  min-width: 0;
+  width: min(260px, 100%);
+  backdrop-filter: blur(8px);
+}
+
+.funnel-stage__label {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.funnel-stage__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.funnel-stage__flow {
+  position: absolute;
+  top: 50%;
+  width: clamp(110px, 16vw, 180px);
+  height: 24px;
+  border-radius: 0 999px 999px 0;
+  background: var(--funnel-stage-gradient);
+  opacity: 0.95;
+  transform: translateY(-50%);
+  z-index: -1;
+  filter: blur(0.3px);
+}
+
+.funnel-stage--left {
+  text-align: right;
+  align-items: flex-end;
+}
+
+.funnel-stage--left .funnel-stage__flow {
+  right: calc(-1 * clamp(110px, 16vw, 180px));
+}
+
+.funnel-stage--right {
+  text-align: left;
+  align-items: flex-start;
+}
+
+.funnel-stage--right .funnel-stage__flow {
+  left: calc(-1 * clamp(110px, 16vw, 180px));
+  border-radius: 999px 0 0 999px;
+}
+
+.funnel-center {
+  position: relative;
+  width: min(240px, 100%);
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.95), rgba(221, 227, 255, 0.9));
+  box-shadow: 0 30px 80px rgba(84, 107, 204, 0.28);
+  display: grid;
+  place-items: center;
+  text-align: center;
+  color: var(--text-strong);
+  z-index: 2;
+  overflow: hidden;
+}
+
+.funnel-center__ring {
+  position: absolute;
+  inset: 10%;
+  border-radius: 50%;
+  background: radial-gradient(circle, rgba(129, 106, 255, 0.25), transparent 70%);
+  filter: blur(12px);
+  z-index: -1;
+}
+
+.funnel-center__eyebrow {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.funnel-center__value {
+  font-size: clamp(3rem, 5vw, 3.6rem);
+  font-weight: 700;
+  line-height: 1;
+}
+
+.funnel-center__amount {
+  font-size: 1rem;
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.funnel-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.5rem;
+}
+
+.funnel-metric {
+  padding: 1.1rem 1.25rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.82);
+  box-shadow: 0 18px 36px rgba(71, 85, 172, 0.16);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+  text-align: left;
+}
+
+.funnel-metric__label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.funnel-metric__value {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.funnel-metric__detail {
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.funnel-metric--positive .funnel-metric__detail {
+  color: var(--success);
+}
+
+.funnel-metric--negative .funnel-metric__detail {
+  color: var(--danger);
+}
+
+.funnel-metric--neutral .funnel-metric__detail {
+  color: var(--neutral);
+}
+
 .time-filter {
   display: inline-flex;
   gap: 0.4rem;
@@ -1210,6 +1519,15 @@ body {
       'overview totals';
   }
 
+  .funnel-card {
+    padding: 2.1rem;
+  }
+
+  .funnel-visualization {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 220px) minmax(0, 1fr);
+    gap: 2rem;
+  }
+
   .overview {
     grid-area: overview;
   }
@@ -1238,6 +1556,45 @@ body {
     align-self: flex-end;
   }
 
+  .funnel-card {
+    padding: 1.9rem;
+  }
+
+  .funnel-card__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .funnel-card__header-meta {
+    align-self: flex-start;
+  }
+
+  .funnel-visualization {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.5rem;
+  }
+
+  .funnel-column {
+    align-items: stretch;
+  }
+
+  .funnel-stage,
+  .funnel-stage--left,
+  .funnel-stage--right {
+    align-items: flex-start;
+    text-align: left;
+    width: 100%;
+  }
+
+  .funnel-stage__flow {
+    display: none;
+  }
+
+  .funnel-center {
+    width: min(220px, 70vw);
+    margin: 0 auto;
+  }
+
   .dashboard-grid {
     grid-template-columns: 1fr;
   }
@@ -1249,6 +1606,10 @@ body {
   .metric-grid {
     grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
   }
+
+  .funnel-metrics {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  }
 }
 
 @media (max-width: 600px) {
@@ -1258,6 +1619,29 @@ body {
 
   .totals-panel__highlight {
     font-size: 1.5rem;
+  }
+
+  .page-nav {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .page-nav__button {
+    flex: 1 1 auto;
+    min-width: 140px;
+    text-align: center;
+  }
+
+  .funnel-card {
+    padding: 1.6rem 1.5rem;
+  }
+
+  .funnel-card__title {
+    font-size: 2.2rem;
+  }
+
+  .funnel-metrics {
+    grid-template-columns: 1fr;
   }
 
   .earnings-list__row {


### PR DESCRIPTION
## Summary
- add navigation tabs so the dashboard can switch between the overview and a new Funnel Stages view
- implement the FunnelStages component with stylised stage flows, totals, and quick metrics
- extend the global styles for the new funnel layout and ensure responsive behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ae33e7f483288a5cd7cd1ec287a5