### PR TITLE
Adjust funnel layout width to match overview page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -142,12 +142,14 @@ body {
 .funnel-layout {
   display: flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .funnel-card {
   padding: 2.4rem 2.7rem;
   position: relative;
   overflow: hidden;
+  width: 100%;
 }
 
 .funnel-card::before,


### PR DESCRIPTION
## Summary
- ensure the funnel stage layout stretches across the shell like the overview page by enforcing full-width styles on the container and card

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2df200c188328ace9cf0da5a759f2