### PR TITLE
Ensure funnel layout matches overview width

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -42,6 +42,9 @@ body {
 .app {
   position: relative;
   width: 100%;
+  flex: 1 1 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .background-blob {
@@ -73,6 +76,8 @@ body {
   z-index: 1;
   max-width: 1200px;
   width: 100%;
+  flex: 1 1 1200px;
+  margin: 0 auto;
 }
 
 .page-header {


### PR DESCRIPTION
## Summary
- allow the top-level app container to grow with its flex parent so both pages share the same maximum width
- keep the shell centered at the dashboard's 1200px max width when switching between overview and funnel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2feb81a108328824ebcc98a3b22fe