### PR TITLE
Ensure funnel layout uses full width

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -148,6 +148,14 @@ body {
   display: flex;
   flex-direction: column;
   width: 100%;
+  flex: 1 1 100%;
+  align-items: stretch;
+  min-width: 0;
+}
+
+.funnel-layout > * {
+  width: 100%;
+  max-width: none;
 }
 
 .funnel-card {


### PR DESCRIPTION
## Summary
- stretch the funnel page layout to occupy the full shell width like the overview grid
- ensure any funnel layout child card is allowed to expand across the available space

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d308cf2a588328aaf5a154d404d2b8