### PR TITLE
Ensure funnel stage page matches overview width

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,10 @@ body {
   padding: 4rem 1.5rem;
 }
 
+#root {
+  width: 100%;
+}
+
 .app {
   position: relative;
   width: 100%;


### PR DESCRIPTION
## Summary
- ensure the React root element stretches to the full viewport width so the funnel stage layout can use the same width as the overview page

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68d3d0357cac8328a1d79642f62101af