### PR TITLE
Replace funnel visualization with Sankey chart

### DIFF
--- a/src/components/SankeyChart.jsx
+++ b/src/components/SankeyChart.jsx
@@ -1,0 +1,257 @@
+import { useId, useMemo } from 'react';
+import PropTypes from 'prop-types';
+
+const sanitizeId = (value) => value.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+
+const computeSankeyLayout = (nodes, links, width, height, nodeWidth, nodeGap, margin) => {
+  const sources = nodes.filter((node) => node.side === 'left');
+  const targets = nodes.filter((node) => node.side === 'right');
+  const totalValue = sources.reduce((sum, node) => sum + node.value, 0);
+
+  if (!nodes.length || !links.length || totalValue <= 0) {
+    return { nodes: [], links: [] };
+  }
+
+  const availableLeftHeight = height - margin.top - margin.bottom - nodeGap * Math.max(sources.length - 1, 0);
+  const availableRightHeight = height - margin.top - margin.bottom - nodeGap * Math.max(targets.length - 1, 0);
+  const scale = Math.min(availableLeftHeight / totalValue, availableRightHeight / totalValue);
+
+  const positionColumn = (columnNodes, side) => {
+    if (!columnNodes.length) {
+      return [];
+    }
+
+    const x0 = side === 'left' ? margin.left : width - margin.right - nodeWidth;
+    const x1 = x0 + nodeWidth;
+    const totalHeight = columnNodes.reduce((sum, node) => sum + node.value * scale, 0);
+    const totalGap = nodeGap * Math.max(columnNodes.length - 1, 0);
+    const extraSpace = height - margin.top - margin.bottom - totalHeight - totalGap;
+    let currentY = margin.top + (extraSpace > 0 ? extraSpace / 2 : 0);
+
+    return columnNodes.map((node) => {
+      const nodeHeight = node.value * scale;
+      const positioned = {
+        ...node,
+        x0,
+        x1,
+        y0: currentY,
+        y1: currentY + nodeHeight,
+        height: nodeHeight,
+      };
+      currentY = positioned.y1 + nodeGap;
+      return positioned;
+    });
+  };
+
+  const positionedSources = positionColumn(sources, 'left');
+  const positionedTargets = positionColumn(targets, 'right');
+  const positionedNodes = [...positionedSources, ...positionedTargets];
+  const nodeById = new Map(positionedNodes.map((node) => [node.id, node]));
+  const sourceOffsets = Object.create(null);
+  const targetOffsets = Object.create(null);
+
+  const positionedLinks = links
+    .map((link, index) => {
+      const sourceNode = nodeById.get(link.source);
+      const targetNode = nodeById.get(link.target);
+
+      if (!sourceNode || !targetNode || link.value <= 0) {
+        return null;
+      }
+
+      const linkHeight = link.value * scale;
+      const sourceOffset = sourceOffsets[link.source] || 0;
+      const targetOffset = targetOffsets[link.target] || 0;
+      const sourceY0 = sourceNode.y0 + sourceOffset;
+      const sourceY1 = sourceY0 + linkHeight;
+      const targetY0 = targetNode.y0 + targetOffset;
+      const targetY1 = targetY0 + linkHeight;
+
+      sourceOffsets[link.source] = sourceOffset + linkHeight;
+      targetOffsets[link.target] = targetOffset + linkHeight;
+
+      const sourceX = sourceNode.x1;
+      const targetX = targetNode.x0;
+      const midpointX = sourceX + (targetX - sourceX) * 0.5;
+
+      const path = [
+        `M ${sourceX} ${sourceY0}`,
+        `C ${midpointX} ${sourceY0}, ${midpointX} ${targetY0}, ${targetX} ${targetY0}`,
+        `L ${targetX} ${targetY1}`,
+        `C ${midpointX} ${targetY1}, ${midpointX} ${sourceY1}, ${sourceX} ${sourceY1}`,
+        'Z',
+      ].join(' ');
+
+      return {
+        ...link,
+        index,
+        path,
+        sourceX,
+        targetX,
+        sourceNode,
+        targetNode,
+        value: link.value,
+        gradientId: `link-gradient-${sanitizeId(`${link.source}-${link.target}-${index}`)}`,
+      };
+    })
+    .filter(Boolean);
+
+  return { nodes: positionedNodes, links: positionedLinks };
+};
+
+const SankeyChart = ({
+  nodes,
+  links,
+  valueFormatter,
+  title,
+  description,
+  width,
+  height,
+  nodeWidth,
+  nodeGap,
+  margin,
+}) => {
+  const layout = useMemo(
+    () => computeSankeyLayout(nodes, links, width, height, nodeWidth, nodeGap, margin),
+    [nodes, links, width, height, nodeWidth, nodeGap, margin]
+  );
+  const titleId = useId();
+  const descriptionId = description ? `${titleId}-desc` : undefined;
+
+  return (
+    <svg
+      className="sankey-chart"
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-labelledby={descriptionId ? `${titleId} ${descriptionId}` : titleId}
+    >
+      <title id={titleId}>{title}</title>
+      {description ? <desc id={descriptionId}>{description}</desc> : null}
+
+      <defs>
+        {layout.nodes.map((node) => (
+          <linearGradient
+            key={node.id}
+            id={`node-gradient-${sanitizeId(node.id)}`}
+            x1="0%"
+            y1="0%"
+            x2="100%"
+            y2="0%"
+          >
+            <stop offset="0%" stopColor={node.colors[0]} />
+            <stop offset="100%" stopColor={node.colors[1]} />
+          </linearGradient>
+        ))}
+
+        {layout.links.map((link) => (
+          <linearGradient
+            key={link.gradientId}
+            id={link.gradientId}
+            gradientUnits="userSpaceOnUse"
+            x1={link.sourceX}
+            x2={link.targetX}
+            y1="0"
+            y2="0"
+          >
+            <stop offset="0%" stopColor={link.sourceNode.colors[0]} stopOpacity="0.85" />
+            <stop
+              offset="100%"
+              stopColor={link.targetNode.colors[1] || link.targetNode.colors[0]}
+              stopOpacity="0.75"
+            />
+          </linearGradient>
+        ))}
+      </defs>
+
+      <g className="sankey-chart__links" fill="none">
+        {layout.links.map((link) => (
+          <path key={link.gradientId} d={link.path} fill={`url(#${link.gradientId})`} className="sankey-chart__link">
+            <title>
+              {`${link.source} to ${link.target}: ${valueFormatter(link.value)}`}
+            </title>
+          </path>
+        ))}
+      </g>
+
+      <g className="sankey-chart__nodes">
+        {layout.nodes.map((node) => {
+          const labelX = node.side === 'left' ? node.x0 - 18 : node.x1 + 18;
+          const textAnchor = node.side === 'left' ? 'end' : 'start';
+          const labelY = (node.y0 + node.y1) / 2 - 6;
+
+          return (
+            <g key={node.id} className="sankey-chart__node">
+              <rect
+                x={node.x0}
+                y={node.y0}
+                width={node.x1 - node.x0}
+                height={node.y1 - node.y0}
+                rx={14}
+                ry={14}
+                fill={`url(#node-gradient-${sanitizeId(node.id)})`}
+                className="sankey-chart__node-rect"
+                style={{ filter: `drop-shadow(0 18px 36px ${node.shadow})` }}
+              >
+                <title>{`${node.label}: ${valueFormatter(node.value)}`}</title>
+              </rect>
+              <text x={labelX} y={labelY} textAnchor={textAnchor} className="sankey-node__text">
+                <tspan x={labelX} className="sankey-node__label">
+                  {node.label}
+                </tspan>
+                <tspan x={labelX} dy="1.3em" className="sankey-node__value">
+                  {valueFormatter(node.value)}
+                </tspan>
+              </text>
+            </g>
+          );
+        })}
+      </g>
+    </svg>
+  );
+};
+
+SankeyChart.propTypes = {
+  nodes: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      side: PropTypes.oneOf(['left', 'right']).isRequired,
+      value: PropTypes.number.isRequired,
+      colors: PropTypes.arrayOf(PropTypes.string).isRequired,
+      shadow: PropTypes.string,
+    })
+  ).isRequired,
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      source: PropTypes.string.isRequired,
+      target: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+  valueFormatter: PropTypes.func,
+  title: PropTypes.string,
+  description: PropTypes.string,
+  width: PropTypes.number,
+  height: PropTypes.number,
+  nodeWidth: PropTypes.number,
+  nodeGap: PropTypes.number,
+  margin: PropTypes.shape({
+    top: PropTypes.number,
+    right: PropTypes.number,
+    bottom: PropTypes.number,
+    left: PropTypes.number,
+  }),
+};
+
+SankeyChart.defaultProps = {
+  valueFormatter: (value) => value.toLocaleString('en-US'),
+  title: 'Sankey diagram',
+  description: undefined,
+  width: 780,
+  height: 420,
+  nodeWidth: 26,
+  nodeGap: 32,
+  margin: { top: 12, right: 96, bottom: 12, left: 96 },
+};
+
+export default SankeyChart;

--- a/src/index.css
+++ b/src/index.css
@@ -258,138 +258,95 @@ body {
 }
 
 .funnel-visualization {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  align-items: center;
-  gap: 2.5rem;
-}
-
-.funnel-column {
   display: flex;
-  flex-direction: column;
-  gap: 1.4rem;
-  position: relative;
-  z-index: 1;
+  justify-content: center;
+  padding: 1rem 0 0;
+  overflow: visible;
 }
 
-.funnel-column--left {
-  align-items: flex-end;
+.sankey-chart {
+  width: min(100%, 820px);
+  height: auto;
+  max-width: 820px;
 }
 
-.funnel-column--right {
-  align-items: flex-start;
+.sankey-chart__link {
+  fill-opacity: 0.65;
+  transition: fill-opacity 0.2s ease;
 }
 
-
-.funnel-stage {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  padding: 0.95rem 1.2rem;
-  border-radius: 18px;
-  background: rgba(255, 255, 255, 0.9);
-  box-shadow: 0 18px 40px var(--funnel-stage-shadow, rgba(107, 91, 255, 0.18));
-  min-width: 0;
-  width: min(260px, 100%);
-  backdrop-filter: blur(8px);
+.sankey-chart__link:hover,
+.sankey-chart__link:focus {
+  fill-opacity: 0.85;
 }
 
-.funnel-stage__label {
+.sankey-chart__node-rect {
+  stroke: rgba(255, 255, 255, 0.9);
+  stroke-width: 1px;
+}
+
+.sankey-node__text {
+  font-size: 0.85rem;
+  fill: var(--text-muted);
+}
+
+.sankey-node__label {
   font-size: 0.95rem;
   font-weight: 600;
-  color: var(--text-muted);
+  fill: var(--text-strong);
 }
 
-.funnel-stage__value {
-  font-size: 1.4rem;
-  font-weight: 700;
-  color: var(--text-strong);
-}
-
-.funnel-stage--left {
-  text-align: right;
-  align-items: flex-end;
-}
-
-.funnel-stage--right {
-  text-align: left;
-  align-items: flex-start;
-}
-
-.funnel-flow {
-  --funnel-flow-width: clamp(200px, 22vw, 280px);
-  --funnel-flow-height: clamp(48px, 8vw, 72px);
-  position: absolute;
-  top: 50%;
-  left: 100%;
-  width: var(--funnel-flow-width);
-  height: var(--funnel-flow-height);
-  transform: translateY(-50%);
-  filter: drop-shadow(0 18px 32px var(--funnel-flow-shadow, rgba(107, 91, 255, 0.18)));
-  overflow: visible;
-  z-index: -1;
-}
-
-.funnel-flow__path {
-  opacity: 0.95;
-}
-
-.funnel-flow__highlight {
-  opacity: 0.65;
-}
-
-.funnel-stage--left .funnel-flow {
-  margin-left: 18px;
-}
-
-.funnel-stage--right .funnel-flow {
-  left: auto;
-  right: 100%;
-  margin-right: 18px;
-  transform: translateY(-50%) scaleX(-1);
-}
-
-.funnel-center {
-  position: relative;
-  width: min(240px, 100%);
-  aspect-ratio: 1 / 1;
-  border-radius: 50%;
-  background: radial-gradient(circle at 50% 50%, rgba(255, 255, 255, 0.95), rgba(221, 227, 255, 0.9));
-  box-shadow: 0 30px 80px rgba(84, 107, 204, 0.28);
-  display: grid;
-  place-items: center;
-  text-align: center;
-  color: var(--text-strong);
-  z-index: 2;
-  overflow: hidden;
-}
-
-.funnel-center__ring {
-  position: absolute;
-  inset: 10%;
-  border-radius: 50%;
-  background: radial-gradient(circle, rgba(129, 106, 255, 0.25), transparent 70%);
-  filter: blur(12px);
-  z-index: -1;
-}
-
-.funnel-center__eyebrow {
+.sankey-node__value {
   font-size: 0.85rem;
+  font-weight: 500;
+  fill: var(--text-muted);
+}
+
+.funnel-stage-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.6rem;
+  align-items: stretch;
+}
+
+.funnel-stage-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.funnel-stage-group__title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
   color: var(--text-muted);
   font-weight: 600;
 }
 
-.funnel-center__value {
-  font-size: clamp(3rem, 5vw, 3.6rem);
-  font-weight: 700;
-  line-height: 1;
+.funnel-stage-card {
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 38px var(--stage-card-shadow, rgba(107, 91, 255, 0.16));
+  color: var(--text-strong);
+  backdrop-filter: blur(6px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
 }
 
-.funnel-center__amount {
-  font-size: 1rem;
-  color: var(--primary);
+.funnel-stage-card__label {
+  font-size: 0.85rem;
   font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.funnel-stage-card__value {
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--text-strong);
 }
 
 .funnel-metrics {
@@ -1601,29 +1558,15 @@ body {
   }
 
   .funnel-visualization {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.5rem;
+    padding: 0.5rem 0 0;
   }
 
-  .funnel-column {
-    align-items: stretch;
+  .sankey-chart {
+    max-width: 100%;
   }
 
-  .funnel-stage,
-  .funnel-stage--left,
-  .funnel-stage--right {
-    align-items: flex-start;
-    text-align: left;
-    width: 100%;
-  }
-
-  .funnel-stage__flow {
-    display: none;
-  }
-
-  .funnel-center {
-    width: min(220px, 70vw);
-    margin: 0 auto;
+  .funnel-stage-summary {
+    grid-template-columns: 1fr;
   }
 
   .dashboard-grid {


### PR DESCRIPTION
## Summary
- add a reusable `SankeyChart` component that lays out two-column flows with gradients
- update the funnel page to drive the Sankey diagram from stage/link data and show stage totals
- refresh the funnel styles for the new chart and supporting summaries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3d8ccaed883289913b87649064ef9