### PR TITLE
Improve readability of funnel stage cards

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -328,17 +328,18 @@ body {
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.92);
   box-shadow: 0 18px 38px var(--stage-card-shadow, rgba(107, 91, 255, 0.16));
-  color: var(--text-strong);
+  color: #ffffff;
   backdrop-filter: blur(6px);
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
+  text-shadow: 0 2px 10px rgba(17, 24, 39, 0.3);
 }
 
 .funnel-stage-card__label {
   font-size: 0.85rem;
   font-weight: 600;
-  color: var(--text-muted);
+  color: rgba(255, 255, 255, 0.85);
   text-transform: uppercase;
   letter-spacing: 0.05em;
 }
@@ -346,7 +347,7 @@ body {
 .funnel-stage-card__value {
   font-size: 1.35rem;
   font-weight: 700;
-  color: var(--text-strong);
+  color: #ffffff;
 }
 
 .funnel-metrics {


### PR DESCRIPTION
## Summary
- update funnel stage card styles to use high-contrast white text and subtle shadowing over gradient backgrounds
- adjust label and value colors for stage cards to remain legible across all gradients

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3fef7d0748328acd2c65c76a4ba7d