### PR TITLE
Hide redundant Sheet timeframe control on overview

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -93,11 +93,13 @@ const App = () => {
                 <button type="button" className="sheet-trigger" onClick={() => setIsSheetOpen(true)}>
                   Sheet
                 </button>
-                <TimeFilter
-                  options={TIMEFRAME_OPTIONS}
-                  activeId={activeTimeframe}
-                  onSelect={setActiveTimeframe}
-                />
+                {TIMEFRAME_OPTIONS.length > 1 ? (
+                  <TimeFilter
+                    options={TIMEFRAME_OPTIONS}
+                    activeId={activeTimeframe}
+                    onSelect={setActiveTimeframe}
+                  />
+                ) : null}
               </>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary
- hide the timeframe selector on the overview page when only one timeframe option exists so the duplicate Sheet tab disappears

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d40f1ff66c8328877f297e54ad49f0