### PR TITLE
Remove purple glow from overview radar panel

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1313,11 +1313,7 @@ body {
 }
 
 .radar-panel::after {
-  content: '';
-  position: absolute;
-  inset: 20% 30% -10%;
-  background: radial-gradient(circle, rgba(123, 105, 255, 0.35), transparent 70%);
-  z-index: 0;
+  content: none;
 }
 
 .radar-legend {


### PR DESCRIPTION
## Summary
- remove the pseudo-element gradient that added a purple glow below the radar panel on the overview page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d431425784832895e9a28ce6306d6e