### PR TITLE
Add dashboard logo branding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import SheetModal from './components/SheetModal.jsx';
 import FunnelStages from './components/FunnelStages.jsx';
 import { KEYWORD_SHEET_ROWS } from './data/keywordSheet.js';
 import { DASHBOARD_DATA, TIMEFRAME_OPTIONS } from './data/dashboardData.js';
+import medicalLogo from './assets/medical-logo.svg';
 
 const App = () => {
   const [activeTimeframe, setActiveTimeframe] = useState('TY');
@@ -67,7 +68,11 @@ const App = () => {
       <div className="background-blob background-blob--two" aria-hidden="true" />
       <div className="app-shell">
         <header className="page-header">
-          <div>
+          <div className="page-header__content">
+            <div className="page-header__brand" aria-label="Medical Plus dashboard">
+              <img src={medicalLogo} alt="Medical Plus logo" className="page-header__logo" />
+              <span className="page-header__brand-badge">Dashboard</span>
+            </div>
             <h1>{pageMetadata[activePage].title}</h1>
             <p>{pageMetadata[activePage].subtitle}</p>
             <nav className="page-nav" aria-label="Dashboard sections">

--- a/src/assets/medical-logo.svg
+++ b/src/assets/medical-logo.svg
@@ -1,0 +1,9 @@
+<svg width="300" height="96" viewBox="0 0 300 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <text x="0" y="68" fill="#052F3C" font-family="Inter, 'Segoe UI', sans-serif" font-size="64" font-weight="700" letter-spacing="0.02em">
+    medical
+  </text>
+  <g transform="translate(212,16)">
+    <rect x="20" width="16" height="64" rx="8" fill="#19CAD4" />
+    <rect y="24" width="56" height="16" rx="8" fill="#19CAD4" />
+  </g>
+</svg>

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,41 @@ body {
   color: var(--text-strong);
 }
 
+.page-header__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.page-header__brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.35rem 0.6rem 0.35rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.75);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 28px rgba(5, 47, 60, 0.12);
+  width: fit-content;
+}
+
+.page-header__logo {
+  display: block;
+  height: 42px;
+  width: auto;
+}
+
+.page-header__brand-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: #0d5c66;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(25, 202, 212, 0.16);
+}
+
 .page-header__actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add the Medical Plus dashboard logo asset
- show the logo with a dashboard badge in the page header
- style the new branding elements to match the existing glassmorphism theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d435334f3c8328ad60249ae381c9cd