### PR TITLE
Remove header logo from dashboard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,7 +7,6 @@ import SheetModal from './components/SheetModal.jsx';
 import FunnelStages from './components/FunnelStages.jsx';
 import { KEYWORD_SHEET_ROWS } from './data/keywordSheet.js';
 import { DASHBOARD_DATA, TIMEFRAME_OPTIONS } from './data/dashboardData.js';
-import medicalLogo from './assets/medical-logo.svg';
 
 const App = () => {
   const [activeTimeframe, setActiveTimeframe] = useState('TY');
@@ -70,7 +69,6 @@ const App = () => {
         <header className="page-header">
           <div className="page-header__content">
             <div className="page-header__brand" aria-label="Medical Plus dashboard">
-              <img src={medicalLogo} alt="Medical Plus logo" className="page-header__logo" />
               <span className="page-header__brand-badge">Dashboard</span>
             </div>
             <h1>{pageMetadata[activePage].title}</h1>

--- a/src/index.css
+++ b/src/index.css
@@ -101,19 +101,13 @@ body {
 .page-header__brand {
   display: inline-flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.35rem 0.6rem 0.35rem 0.35rem;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
   border-radius: 999px;
   background: rgba(255, 255, 255, 0.75);
   backdrop-filter: blur(12px);
   box-shadow: 0 12px 28px rgba(5, 47, 60, 0.12);
   width: fit-content;
-}
-
-.page-header__logo {
-  display: block;
-  height: 42px;
-  width: auto;
 }
 
 .page-header__brand-badge {


### PR DESCRIPTION
## Summary
- remove the Medical Plus logo from the dashboard header
- adjust the header badge spacing now that the logo is gone

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d65937e7148328a96683fb3fbb1f66