### PR TITLE
Remove Secondary Keywords column from sheet modal

### DIFF
--- a/src/services/intentClassification.js
+++ b/src/services/intentClassification.js
@@ -121,7 +121,6 @@ const buildUserPrompt = (items) => {
   const keywords = items.map((item) => ({
     index: item.index,
     primary: item.primary,
-    secondary: item.secondary,
   }));
 
   return [
@@ -209,7 +208,6 @@ export const classifyKeywordIntents = async (rows, options = {}) => {
     const items = chunk.map((row, index) => ({
       index: start + index + 1,
       primary: sanitiseKeyword(row.primaryKeyword),
-      secondary: sanitiseKeyword(row.secondaryKeyword),
     }));
 
     // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
## Summary
- remove the Secondary Keywords column and schema entry from the sheet modal
- update keyword ingestion, deduplication, and previews to operate on primary keywords only
- simplify intent classification requests by excluding the unused secondary keyword field

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d67249d7d8832891dc2c4e6eaff0b7