### PR TITLE
Add star emoji to quick win label

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -215,7 +215,7 @@ const SeoOpportunity = () => {
           </ul>
 
           <div className="seo-keyword-callout">
-            <p className="seo-keyword-callout__label">Best quick win</p>
+            <p className="seo-keyword-callout__label">⭐ Best quick win</p>
             {quickWinKeyword ? (
               <>
                 <p className="seo-keyword-callout__keyword">{quickWinKeyword.topic}</p>


### PR DESCRIPTION
## Summary
- add a star emoji to the quick win label to highlight the top opportunity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d67fb3bc4c832884957ed3ba1041cc