### PR TITLE
Remove dashboard badge from header branding

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,9 +82,7 @@ const App = () => {
       <div className="app-shell">
         <header className="page-header">
           <div className="page-header__content">
-            <div className="page-header__brand" aria-label="Medical Plus dashboard">
-              <span className="page-header__brand-badge">Dashboard</span>
-            </div>
+            <div className="page-header__brand" aria-label="Medical Plus" />
             <h1>{pageMetadata[activePage].title}</h1>
             <p>{pageMetadata[activePage].subtitle}</p>
             <nav className="page-nav" aria-label="Dashboard sections">


### PR DESCRIPTION
## Summary
- remove the dashboard badge text from the header brand section
- update the header brand aria-label to drop the dashboard wording

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6a62bb82c8328bc91f966cf9cc156