### PR TITLE
Remove unused page header brand element

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -82,7 +82,6 @@ const App = () => {
       <div className="app-shell">
         <header className="page-header">
           <div className="page-header__content">
-            <div className="page-header__brand" aria-label="Medical Plus" />
             <h1>{pageMetadata[activePage].title}</h1>
             <p>{pageMetadata[activePage].subtitle}</p>
             <nav className="page-nav" aria-label="Dashboard sections">

--- a/src/index.css
+++ b/src/index.css
@@ -98,29 +98,6 @@ body {
   gap: 0.75rem;
 }
 
-.page-header__brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  background: rgba(255, 255, 255, 0.75);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 12px 28px rgba(5, 47, 60, 0.12);
-  width: fit-content;
-}
-
-.page-header__brand-badge {
-  font-size: 0.75rem;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: #0d5c66;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-  background: rgba(25, 202, 212, 0.16);
-}
-
 .page-header__actions {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- remove the page header brand element from the dashboard layout
- delete the unused styles that supported the brand pill

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a7af58688328a9a0a5ba9862dd84