### PR TITLE
Add global project selector to dashboard header

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,13 @@ const App = () => {
   const [activeTimeframe, setActiveTimeframe] = useState('TY');
   const [activePage, setActivePage] = useState('overview');
   const [isSheetOpen, setIsSheetOpen] = useState(false);
+  const [activeProject, setActiveProject] = useState('atlas-redesign');
+
+  const projectOptions = [
+    { id: 'atlas-redesign', label: 'Atlas Redesign' },
+    { id: 'aurora-insights', label: 'Aurora Insights' },
+    { id: 'nova-growth', label: 'Nova Growth' },
+  ];
 
   const activeData = DASHBOARD_DATA[activeTimeframe];
 
@@ -102,6 +109,26 @@ const App = () => {
             </nav>
           </div>
           <div className="page-header__actions">
+            <div className="project-switcher">
+              <label className="project-switcher__label" htmlFor="project-selector">
+                Projet
+              </label>
+              <select
+                id="project-selector"
+                className="project-switcher__select"
+                value={activeProject}
+                onChange={(event) => setActiveProject(event.target.value)}
+              >
+                {projectOptions.map((project) => (
+                  <option key={project.id} value={project.id}>
+                    {project.label}
+                  </option>
+                ))}
+              </select>
+              <button type="button" className="project-switcher__button">
+                Nouveau projet
+              </button>
+            </div>
             {activePage === 'overview' ? (
               <>
                 <button type="button" className="sheet-trigger" onClick={() => setIsSheetOpen(true)}>

--- a/src/index.css
+++ b/src/index.css
@@ -104,6 +104,62 @@ body {
   gap: 1rem;
 }
 
+.project-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.45rem 0.75rem 0.45rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(107, 91, 255, 0.15);
+  box-shadow: 0 12px 28px rgba(107, 91, 255, 0.16);
+  backdrop-filter: blur(10px);
+}
+
+.project-switcher__label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+}
+
+.project-switcher__select {
+  border: none;
+  background: transparent;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-strong);
+  outline: none;
+  padding-right: 0.25rem;
+  appearance: none;
+  cursor: pointer;
+}
+
+.project-switcher__select::-ms-expand {
+  display: none;
+}
+
+.project-switcher__button {
+  border: none;
+  background: linear-gradient(135deg, #7a6aff, #9f88ff);
+  color: #fff;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 25px rgba(122, 106, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-switcher__button:hover,
+.project-switcher__button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(122, 106, 255, 0.4);
+  outline: none;
+}
+
 .page-header h1 {
   margin: 0 0 0.35rem;
   font-size: clamp(2.4rem, 3vw, 3rem);


### PR DESCRIPTION
## Summary
- add a project picker and new project button to the page header so it stays visible on every page
- style the selector to match the existing dashboard controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6a8c9a838832890a443ac5657e0d9