### PR TITLE
Remove timeframe label from overview subtitle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -23,16 +23,11 @@ const App = () => {
 
   const activeData = DASHBOARD_DATA[activeTimeframe];
 
-  const activeTimeframeLabel = useMemo(() => {
-    const option = TIMEFRAME_OPTIONS.find((item) => item.id === activeTimeframe);
-    return option ? option.name : '';
-  }, [activeTimeframe]);
-
   const pageMetadata = useMemo(
     () => ({
       overview: {
         title: 'General statistics',
-        subtitle: `Total system load${activeTimeframeLabel ? ` · ${activeTimeframeLabel}` : ''}`,
+        subtitle: 'Total system load',
       },
       funnel: {
         title: 'Funnel Stages',
@@ -43,7 +38,7 @@ const App = () => {
         subtitle: 'Map high-potential keywords to focus your optimisation efforts.',
       },
     }),
-    [activeTimeframeLabel]
+    []
   );
 
   const pages = [


### PR DESCRIPTION
## Summary
- remove the timeframe label from the overview subtitle so the header no longer displays "· Sheet"

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6e796b14483289a751c7d6a80d29b