### PR TITLE
Add Supabase authentication flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "@supabase/supabase-js": "^2.43.4",
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.0",

--- a/src/auth/AuthProvider.jsx
+++ b/src/auth/AuthProvider.jsx
@@ -1,0 +1,119 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import { getSupabaseClient, isSupabaseConfigured } from '../services/supabaseClient.js';
+
+const AuthContext = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    let authSubscription = null;
+
+    const initialise = async () => {
+      if (!isSupabaseConfigured) {
+        setUser(null);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        const supabase = await getSupabaseClient();
+        const {
+          data: { session },
+          error,
+        } = await supabase.auth.getSession();
+
+        if (isMounted) {
+          if (!error) {
+            setUser(session?.user ?? null);
+          } else {
+            setUser(null);
+          }
+          setLoading(false);
+        }
+
+        const { data } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+          if (!isMounted) {
+            return;
+          }
+          setUser(nextSession?.user ?? null);
+          setLoading(false);
+        });
+
+        authSubscription = data?.subscription ?? null;
+      } catch (_error) {
+        if (isMounted) {
+          setUser(null);
+          setLoading(false);
+        }
+      }
+    };
+
+    initialise();
+
+    return () => {
+      isMounted = false;
+      if (authSubscription) {
+        authSubscription.unsubscribe();
+      }
+    };
+  }, []);
+
+  const signIn = useCallback(async (email, password) => {
+    if (!isSupabaseConfigured) {
+      throw new Error("Supabase n'est pas configuré.");
+    }
+
+    const supabase = await getSupabaseClient();
+    const { error } = await supabase.auth.signInWithPassword({
+      email: email.trim(),
+      password,
+    });
+
+    if (error) {
+      throw new Error(error.message || 'Identifiants invalides.');
+    }
+  }, []);
+
+  const signOut = useCallback(async () => {
+    if (!isSupabaseConfigured) {
+      setUser(null);
+      return;
+    }
+
+    const supabase = await getSupabaseClient();
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      throw new Error(error.message || 'Impossible de se déconnecter.');
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      user,
+      loading,
+      signIn,
+      signOut,
+    }),
+    [loading, signIn, signOut, user]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth doit être utilisé dans un AuthProvider.');
+  }
+  return context;
+};
+
+export default AuthContext;

--- a/src/auth/RequireAuth.jsx
+++ b/src/auth/RequireAuth.jsx
@@ -1,0 +1,28 @@
+import PropTypes from 'prop-types';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from './AuthProvider.jsx';
+
+const RequireAuth = ({ children }) => {
+  const { user, loading } = useAuth();
+  const location = useLocation();
+
+  if (loading) {
+    return (
+      <div className="auth-spinner" role="status" aria-live="polite">
+        Chargement…
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace state={{ from: location }} />;
+  }
+
+  return children;
+};
+
+RequireAuth.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default RequireAuth;

--- a/src/components/LogoutButton.jsx
+++ b/src/components/LogoutButton.jsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useAuth } from '../auth/AuthProvider.jsx';
+
+const LogoutButton = ({ className, children }) => {
+  const { signOut } = useAuth();
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleClick = async () => {
+    setError(null);
+    setLoading(true);
+    try {
+      await signOut();
+    } catch (logoutError) {
+      setError(logoutError.message || 'Impossible de se déconnecter.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className={className}>
+      <button type="button" onClick={handleClick} disabled={loading} className="logout-button">
+        {children || 'Se déconnecter'}
+      </button>
+      {error ? (
+        <p className="logout-button__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </div>
+  );
+};
+
+LogoutButton.propTypes = {
+  className: PropTypes.string,
+  children: PropTypes.node,
+};
+
+LogoutButton.defaultProps = {
+  className: '',
+  children: null,
+};
+
+export default LogoutButton;

--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,15 @@ body {
   width: 100%;
 }
 
+.auth-spinner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
 .app {
   position: relative;
   width: 100%;
@@ -102,6 +111,43 @@ body {
   display: flex;
   align-items: center;
   gap: 1rem;
+}
+
+.page-header__logout {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+}
+
+.logout-button {
+  border: none;
+  background: rgba(255, 255, 255, 0.75);
+  color: var(--text-strong);
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.logout-button:hover,
+.logout-button:focus-visible {
+  background: rgba(255, 255, 255, 0.95);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.logout-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.logout-button__error {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--danger);
 }
 
 .project-switcher {
@@ -171,6 +217,21 @@ body {
 .project-switcher__button:disabled:focus-visible {
   box-shadow: none;
   transform: none;
+}
+
+.project-switcher__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  align-items: flex-start;
+}
+
+.project-switcher__hint {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--danger);
 }
 
 .page-header h1 {
@@ -735,6 +796,104 @@ body {
   font-weight: 600;
   color: var(--primary);
   justify-self: flex-end;
+}
+
+.login-page {
+  min-height: 80vh;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+}
+
+.login-card {
+  width: min(420px, 100%);
+  padding: 2.5rem 2.75rem;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 28px;
+  box-shadow: 0 40px 80px rgba(93, 95, 144, 0.2);
+  backdrop-filter: blur(12px);
+  color: var(--text-strong);
+}
+
+.login-card__title {
+  margin: 0 0 0.5rem;
+  font-size: 2rem;
+  font-weight: 700;
+}
+
+.login-card__subtitle {
+  margin: 0 0 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-soft);
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.login-form__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.login-form__field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.login-form__field input {
+  border: 1px solid rgba(107, 91, 255, 0.3);
+  border-radius: 14px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.9);
+  color: var(--text-strong);
+}
+
+.login-form__field input:disabled {
+  opacity: 0.6;
+}
+
+.login-form__error {
+  margin: -0.5rem 0 0;
+  color: var(--danger);
+  font-weight: 600;
+}
+
+.login-form__submit {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.4rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: #fff;
+  background: linear-gradient(135deg, #7a6aff, #9f88ff);
+  cursor: pointer;
+  box-shadow: 0 18px 40px rgba(122, 106, 255, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-form__submit:hover,
+.login-form__submit:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 44px rgba(122, 106, 255, 0.4);
+  outline: none;
+}
+
+.login-form__submit:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .funnel-keyword-item--empty {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,28 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import App from './App.jsx';
+import { AuthProvider } from './auth/AuthProvider.jsx';
+import RequireAuth from './auth/RequireAuth.jsx';
+import Login from './pages/Login.jsx';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <App />
+              </RequireAuth>
+            }
+          />
+          <Route path="/login" element={<Login />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   </React.StrictMode>
 );

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth/AuthProvider.jsx';
+
+const Login = () => {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const { signIn, user, loading: authLoading } = useAuth();
+
+  const redirectPath = useMemo(() => location.state?.from?.pathname || '/', [location.state]);
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!authLoading && user) {
+      navigate(redirectPath, { replace: true });
+    }
+  }, [authLoading, navigate, redirectPath, user]);
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError(null);
+
+    const trimmedEmail = email.trim();
+
+    if (trimmedEmail.length === 0 || password.length === 0) {
+      setError('Veuillez renseigner votre email et votre mot de passe.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await signIn(trimmedEmail, password);
+      navigate(redirectPath, { replace: true });
+    } catch (signInError) {
+      setError(signInError.message || 'Identifiants invalides.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const disableForm = submitting || authLoading;
+
+  return (
+    <div className="login-page">
+      <div className="login-card" role="form">
+        <h1 className="login-card__title">Connexion</h1>
+        <p className="login-card__subtitle">Accédez à votre tableau de bord en vous connectant.</p>
+        <form onSubmit={handleSubmit} noValidate className="login-form">
+          <div className="login-form__field">
+            <label htmlFor="login-email">Adresse email</label>
+            <input
+              id="login-email"
+              type="email"
+              name="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              disabled={disableForm}
+              placeholder="vous@example.com"
+            />
+          </div>
+          <div className="login-form__field">
+            <label htmlFor="login-password">Mot de passe</label>
+            <input
+              id="login-password"
+              type="password"
+              name="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              disabled={disableForm}
+            />
+          </div>
+
+          {error ? (
+            <p className="login-form__error" role="alert">
+              {error}
+            </p>
+          ) : null}
+
+          <button type="submit" className="login-form__submit" disabled={disableForm}>
+            {submitting ? 'Connexion…' : 'Se connecter'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -41,7 +41,7 @@ export const fetchProjects = async () => {
   return normalizeProjects(data);
 };
 
-export const createProject = async ({ name, description }) => {
+export const createProject = async ({ name, description, owner = null }) => {
   if (!isSupabaseConfigured) {
     throw new Error("Supabase n'est pas configuré. Impossible de créer le projet.");
   }
@@ -51,19 +51,19 @@ export const createProject = async ({ name, description }) => {
 
   const supabase = await getSupabaseClient();
 
-  // Si l’utilisateur est authentifié, on associe l’owner (policies RLS classiques)
-  let owner = null;
-  try {
-    const { data: userData } = await supabase.auth.getUser();
-    owner = userData?.user?.id || null;
-  } catch {
-    // ignore (ex: Auth non configuré)
-  }
-
   // Payload de base
   const basePayload = {
     name: name.trim(),
   };
+
+  if (!owner) {
+    try {
+      const { data: userData } = await supabase.auth.getUser();
+      owner = userData?.user?.id || null;
+    } catch {
+      owner = null;
+    }
+  }
 
   if (owner) basePayload.owner = owner;
   if (description && String(description).trim().length > 0) {


### PR DESCRIPTION
## Summary
- add an AuthProvider backed by Supabase to expose session state, sign-in, and sign-out helpers
- introduce a login page and router guard so only authenticated users can reach the dashboard
- add a reusable logout button, gate project creation behind authentication, and apply supporting styles

## Testing
- npm run build *(fails: missing local install of react-router-dom in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7d49363288328a8d3e96ec96d9b12