### PR TITLE
Store project-specific sheet data across dashboard

### DIFF
--- a/src/components/FunnelStages.jsx
+++ b/src/components/FunnelStages.jsx
@@ -249,21 +249,24 @@ const computeSankeyNodes = (definitions, links) => {
   });
 };
 
-const FunnelStages = ({ timeframeOptions, activeTimeframe, onTimeframeChange }) => {
+const FunnelStages = ({ timeframeOptions, activeTimeframe, onTimeframeChange, rows }) => {
   const activeOption = timeframeOptions.find((option) => option.id === activeTimeframe);
   const timeframeName = activeOption ? activeOption.name : 'Overview';
   const timeframeLabel = activeOption ? activeOption.label : '';
 
   const { nodes: sankeyNodes, links: sankeyLinks, clusterTotals, stageTotals } = useMemo(
-    () => buildFunnelDataset(KEYWORD_SHEET_ROWS),
-    []
+    () => buildFunnelDataset(rows && rows.length > 0 ? rows : KEYWORD_SHEET_ROWS),
+    [rows]
   );
 
   const quickStats = useMemo(() => computeQuickStats(clusterTotals, stageTotals), [clusterTotals, stageTotals]);
 
   const leftNodes = useMemo(() => sankeyNodes.filter((node) => node.side === 'left'), [sankeyNodes]);
   const rightNodes = useMemo(() => sankeyNodes.filter((node) => node.side === 'right'), [sankeyNodes]);
-  const stageKeywordHighlights = useMemo(() => buildStageKeywordHighlights(KEYWORD_SHEET_ROWS), []);
+  const stageKeywordHighlights = useMemo(
+    () => buildStageKeywordHighlights(rows && rows.length > 0 ? rows : KEYWORD_SHEET_ROWS),
+    [rows]
+  );
 
   return (
     <section className="card funnel-card" aria-labelledby="funnel-title">
@@ -385,6 +388,16 @@ FunnelStages.propTypes = {
   ).isRequired,
   activeTimeframe: PropTypes.string.isRequired,
   onTimeframeChange: PropTypes.func.isRequired,
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      primaryKeyword: PropTypes.string.isRequired,
+    })
+  ),
+};
+
+FunnelStages.defaultProps = {
+  rows: KEYWORD_SHEET_ROWS,
 };
 
 export default FunnelStages;

--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import PropTypes from 'prop-types';
 import {
   SEO_OPPORTUNITY_KEYWORDS,
   SEO_SUMMARY_METRICS,
@@ -11,6 +12,19 @@ const minRadius = 42;
 const maxRadius = 110;
 
 const formatNumber = (value) => value.toLocaleString('en-US');
+
+const COLOR_PALETTE = [
+  '#6b5bff',
+  '#7c6dff',
+  '#8f7bff',
+  '#9d88ff',
+  '#ae94ff',
+  '#c59eff',
+  '#d9a7ff',
+  '#f3b4ff',
+  '#ffc7de',
+  '#ffd4aa',
+];
 
 const QUICK_WIN_RULES = {
   minWs: 20,
@@ -43,54 +57,238 @@ const opportunityToneClass = {
   neutral: 'seo-metric__delta--neutral',
 };
 
-const SeoOpportunity = () => {
-  const maxVolume = useMemo(
-    () => Math.max(...SEO_OPPORTUNITY_KEYWORDS.map((keyword) => keyword.volume)),
-    []
-  );
+const clampNumber = (value, min, max) => {
+  if (!Number.isFinite(value)) {
+    return min;
+  }
+  if (max !== undefined && value > max) {
+    return max;
+  }
+  if (value < min) {
+    return min;
+  }
+  return value;
+};
 
-  const averageOpportunity = useMemo(() => {
-    const total = SEO_OPPORTUNITY_KEYWORDS.reduce((sum, keyword) => sum + keyword.opportunity, 0);
-    return Math.round(total / SEO_OPPORTUNITY_KEYWORDS.length);
-  }, []);
+const clampPercentage = (value) => clampNumber(Number(value ?? 0), 0, 100);
 
-  const highestOpportunityKeyword = useMemo(() => {
-    return (
-      [...SEO_OPPORTUNITY_KEYWORDS].sort((a, b) => b.opportunity - a.opportunity)[0] ??
-      SEO_OPPORTUNITY_KEYWORDS[0]
-    );
-  }, []);
+const buildShortLabel = (row) => {
+  const source = row.cluster || row.primaryKeyword || '';
+  if (source.length <= 18) {
+    return source || 'Keyword';
+  }
+  return `${source.slice(0, 15)}…`;
+};
 
-  const quickWinKeyword = useMemo(() => {
-    const eligible = SEO_OPPORTUNITY_KEYWORDS.filter((keyword) => meetsQuickWinCriteria(keyword));
+const computeOpportunityScore = (row) => {
+  const ws = clampNumber(Number(row.ws ?? 0), 0, 100);
+  const difficulty = clampNumber(Number(row.difficulty ?? 0), 0, 100);
+  const fw = clampNumber(Number(row.fw ?? 1), 1, 3);
+  const momentum = Math.max(0, 100 - difficulty);
+  const rawScore = ws * 0.6 + momentum * 0.3 + fw * 20;
+  return clampNumber(Math.round(rawScore), 10, 100);
+};
 
-    if (!eligible.length) {
-      return null;
+const estimatePosition = (row) => {
+  const ws = clampNumber(Number(row.ws ?? 0), 0, 100);
+  const difficulty = clampNumber(Number(row.difficulty ?? 0), 0, 100);
+  const base = 20 - ws / 5 + difficulty / 20;
+  return Math.max(1, Math.round(base));
+};
+
+const selectQuickWinKeyword = (keywords) => {
+  const eligible = keywords.filter((keyword) => meetsQuickWinCriteria(keyword));
+  if (!eligible.length) {
+    return null;
+  }
+  const [best] = eligible.sort((a, b) => {
+    if (b.ws !== a.ws) {
+      return b.ws - a.ws;
     }
+    if (b.opportunity !== a.opportunity) {
+      return b.opportunity - a.opportunity;
+    }
+    return b.volume - a.volume;
+  });
+  return best || null;
+};
 
-    const [bestQuickWin] = eligible.sort((a, b) => {
-      if (b.ws !== a.ws) {
-        return b.ws - a.ws;
-      }
-      if (b.opportunity !== a.opportunity) {
-        return b.opportunity - a.opportunity;
-      }
-      return b.volume - a.volume;
-    });
-
-    return bestQuickWin;
-  }, []);
-
-  const totalProjectedTraffic = useMemo(
-    () =>
-      SEO_OPPORTUNITY_KEYWORDS.reduce((sum, keyword) => sum + keyword.projectedTraffic, 0),
-    []
+const fallbackSeoDataset = () => {
+  const maxVolume = Math.max(...SEO_OPPORTUNITY_KEYWORDS.map((keyword) => keyword.volume));
+  const averageOpportunity = Math.round(
+    SEO_OPPORTUNITY_KEYWORDS.reduce((sum, keyword) => sum + keyword.opportunity, 0) /
+      SEO_OPPORTUNITY_KEYWORDS.length
   );
+  const totalProjectedTraffic = SEO_OPPORTUNITY_KEYWORDS.reduce(
+    (sum, keyword) => sum + keyword.projectedTraffic,
+    0
+  );
+  const highestOpportunityKeyword = [...SEO_OPPORTUNITY_KEYWORDS]
+    .sort((a, b) => b.opportunity - a.opportunity)
+    .find(Boolean);
+  const quickWinKeyword = selectQuickWinKeyword(SEO_OPPORTUNITY_KEYWORDS);
 
-  const radiusScale = (volume) => {
-    const ratio = volume / maxVolume;
-    return minRadius + ratio * (maxRadius - minRadius);
+  return {
+    keywords: SEO_OPPORTUNITY_KEYWORDS,
+    summary: SEO_SUMMARY_METRICS,
+    maxVolume,
+    averageOpportunity,
+    totalProjectedTraffic,
+    highestOpportunityKeyword: highestOpportunityKeyword || SEO_OPPORTUNITY_KEYWORDS[0],
+    quickWinKeyword,
   };
+};
+
+const buildSeoOpportunityDataset = (rows) => {
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return fallbackSeoDataset();
+  }
+
+  const normalised = rows
+    .map((row) => {
+      const volume = Number(row.volume ?? 0);
+      if (!Number.isFinite(volume) || volume <= 0) {
+        return null;
+      }
+
+      return {
+        id: row.id,
+        primaryKeyword: row.primaryKeyword,
+        cluster: row.cluster || '',
+        volume,
+        difficulty: clampNumber(Number(row.difficulty ?? 0), 0, 100),
+        fw: clampNumber(Number(row.fwValue ?? row.fw ?? 1), 0.5, 3),
+        ws: clampNumber(Number(row.ws ?? 0), 0, 100),
+        intent: row.intent || 'Informational',
+        win: clampPercentage(row.win),
+      };
+    })
+    .filter(Boolean);
+
+  if (!normalised.length) {
+    return fallbackSeoDataset();
+  }
+
+  const sortedByVolume = [...normalised].sort((a, b) => b.volume - a.volume);
+  const limit = Math.min(sortedByVolume.length, 30);
+  const selected = sortedByVolume.slice(0, limit);
+
+  const keywords = selected.map((row, index) => {
+    const opportunity = computeOpportunityScore(row);
+    const projectedTraffic = Math.round((row.volume * row.win) / 100);
+    const color = COLOR_PALETTE[index % COLOR_PALETTE.length];
+    const shortLabel = buildShortLabel(row);
+    const currentPosition = estimatePosition(row);
+    const quickWin = meetsQuickWinCriteria({ ...row, opportunity });
+
+    return {
+      id: row.id || `seo-${index}`,
+      topic: row.cluster || row.primaryKeyword,
+      shortLabel,
+      volume: row.volume,
+      difficulty: row.difficulty,
+      fw: row.fw,
+      ws: row.ws,
+      intent: row.intent,
+      opportunity,
+      currentPosition,
+      projectedTraffic,
+      color,
+      quickWin,
+      x: 0,
+      y: 0,
+    };
+  });
+
+  const columnCount = Math.max(1, Math.ceil(Math.sqrt(keywords.length)));
+  const rowCount = Math.max(1, Math.ceil(keywords.length / columnCount));
+  const xSpacing = chartWidth / (columnCount + 1);
+  const ySpacing = chartHeight / (rowCount + 1);
+
+  keywords.forEach((keyword, index) => {
+    const columnIndex = index % columnCount;
+    const rowIndex = Math.floor(index / columnCount);
+    keyword.x = Math.round(xSpacing * (columnIndex + 1));
+    keyword.y = Math.round(ySpacing * (rowIndex + 1));
+  });
+
+  const maxVolume = Math.max(...keywords.map((keyword) => keyword.volume));
+  const averageOpportunity = Math.round(
+    keywords.reduce((sum, keyword) => sum + keyword.opportunity, 0) / keywords.length
+  );
+  const totalProjectedTraffic = keywords.reduce(
+    (sum, keyword) => sum + keyword.projectedTraffic,
+    0
+  );
+  const highestOpportunityKeyword = keywords.reduce((best, keyword) => {
+    if (!best || keyword.opportunity > best.opportunity) {
+      return keyword;
+    }
+    return best;
+  }, null);
+
+  const quickWinKeyword = selectQuickWinKeyword(keywords);
+  const quickWinCount = keywords.filter((keyword) => keyword.quickWin).length;
+
+  const summary = [
+    {
+      id: 'growth',
+      label: 'Avg. opportunity score',
+      value: `${averageOpportunity}`,
+      delta:
+        quickWinCount > 0
+          ? `${quickWinCount} quick win${quickWinCount > 1 ? 's' : ''}`
+          : 'No quick wins detected',
+      tone: quickWinCount > 0 ? 'positive' : 'neutral',
+    },
+    {
+      id: 'coverage',
+      label: 'Keywords in sheet',
+      value: `${keywords.length}`,
+      delta:
+        normalised.length > keywords.length
+          ? `${normalised.length - keywords.length} filtered (low volume)`
+          : 'All sheet keywords',
+      tone: 'neutral',
+    },
+    {
+      id: 'traffic',
+      label: 'Projected lift',
+      value: `${formatNumber(totalProjectedTraffic)} visits`,
+      delta: 'Based on win rate',
+      tone: totalProjectedTraffic > 0 ? 'positive' : 'neutral',
+    },
+  ];
+
+  return {
+    keywords,
+    summary,
+    maxVolume,
+    averageOpportunity,
+    totalProjectedTraffic,
+    highestOpportunityKeyword: highestOpportunityKeyword || keywords[0],
+    quickWinKeyword,
+  };
+};
+
+const SeoOpportunity = ({ rows }) => {
+  const {
+    keywords,
+    summary,
+    maxVolume,
+    averageOpportunity,
+    totalProjectedTraffic,
+    highestOpportunityKeyword,
+    quickWinKeyword,
+  } = useMemo(() => buildSeoOpportunityDataset(rows), [rows]);
+
+  const radiusScale = useMemo(() => {
+    const safeMax = maxVolume || 1;
+    return (volume) => {
+      const ratio = safeMax ? volume / safeMax : 0;
+      return minRadius + ratio * (maxRadius - minRadius);
+    };
+  }, [maxVolume]);
 
   const renderBubbleLabel = (keyword, radius) => {
     const isCompact = radius < 70;
@@ -99,11 +297,7 @@ const SeoOpportunity = () => {
         <text className="seo-bubble__label" y={isCompact ? 6 : -2} textAnchor="middle">
           {keyword.shortLabel}
         </text>
-        <text
-          className="seo-bubble__meta"
-          y={isCompact ? 24 : 20}
-          textAnchor="middle"
-        >
+        <text className="seo-bubble__meta" y={isCompact ? 24 : 20} textAnchor="middle">
           {formatNumber(keyword.volume)} searches
         </text>
       </>
@@ -148,7 +342,7 @@ const SeoOpportunity = () => {
             aria-hidden="true"
           >
             <defs>
-              {SEO_OPPORTUNITY_KEYWORDS.map((keyword) => (
+              {keywords.map((keyword) => (
                 <radialGradient
                   key={keyword.id}
                   id={`bubble-gradient-${keyword.id}`}
@@ -163,14 +357,10 @@ const SeoOpportunity = () => {
               ))}
             </defs>
 
-            {SEO_OPPORTUNITY_KEYWORDS.map((keyword) => {
+            {keywords.map((keyword) => {
               const radius = radiusScale(keyword.volume);
               return (
-                <g
-                  key={keyword.id}
-                  transform={`translate(${keyword.x}, ${keyword.y})`}
-                  className="seo-bubble"
-                >
+                <g key={keyword.id} transform={`translate(${keyword.x}, ${keyword.y})`} className="seo-bubble">
                   <circle
                     className="seo-bubble__circle"
                     r={radius}
@@ -185,8 +375,8 @@ const SeoOpportunity = () => {
           </svg>
           <figcaption id="seo-bubble-caption" className="seo-bubble-chart__caption">
             Highlighted keyword &ldquo;{highestOpportunityKeyword.shortLabel}&rdquo; offers the highest opportunity score at{' '}
-            {highestOpportunityKeyword.opportunity} with{' '}
-            {formatNumber(highestOpportunityKeyword.volume)} monthly searches.
+            {highestOpportunityKeyword.opportunity} with {formatNumber(highestOpportunityKeyword.volume)} monthly
+            searches.
           </figcaption>
         </figure>
 
@@ -204,13 +394,11 @@ const SeoOpportunity = () => {
           </div>
 
           <ul className="seo-metrics" role="list">
-            {SEO_SUMMARY_METRICS.map((metric) => (
+            {summary.map((metric) => (
               <li key={metric.id} className="seo-metric" role="listitem">
                 <p className="seo-metric__label">{metric.label}</p>
                 <p className="seo-metric__value">{metric.value}</p>
-                <p className={`seo-metric__delta ${opportunityToneClass[metric.tone]}`}>
-                  {metric.delta}
-                </p>
+                <p className={`seo-metric__delta ${opportunityToneClass[metric.tone]}`}>{metric.delta}</p>
               </li>
             ))}
           </ul>
@@ -239,6 +427,19 @@ const SeoOpportunity = () => {
       </div>
     </section>
   );
+};
+
+SeoOpportunity.propTypes = {
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      primaryKeyword: PropTypes.string.isRequired,
+    })
+  ),
+};
+
+SeoOpportunity.defaultProps = {
+  rows: [],
 };
 
 export default SeoOpportunity;

--- a/src/components/SheetModal.jsx
+++ b/src/components/SheetModal.jsx
@@ -614,7 +614,7 @@ const formatCellValue = (column, row) => {
   return value ?? '';
 };
 
-const SheetModal = ({ open, onClose, rows }) => {
+const SheetModal = ({ open, onClose, rows, onRowsChange }) => {
   const [tableRows, setTableRows] = useState(() => prepareTableRows(rows));
   const updateTableRows = useCallback(
     (updater) => {
@@ -623,10 +623,14 @@ const SheetModal = ({ open, onClose, rows }) => {
         if (!Array.isArray(next)) {
           return previous;
         }
-        return applyWsScoreToRows(next);
+        const withScores = applyWsScoreToRows(next);
+        if (onRowsChange) {
+          onRowsChange(withScores.map((row) => ({ ...row })));
+        }
+        return withScores;
       });
     },
-    [setTableRows]
+    [setTableRows, onRowsChange]
   );
   const [intentFilter, setIntentFilter] = useState('All');
   const [stageFilter, setStageFilter] = useState('All');
@@ -2113,6 +2117,7 @@ SheetModal.propTypes = {
       page: PropTypes.string,
     })
   ).isRequired,
+  onRowsChange: PropTypes.func,
 };
 
 export default SheetModal;


### PR DESCRIPTION
## Summary
- persist sheet rows per project and expose them to the funnel and SEO dashboards
- notify the parent when SheetModal rows change so imported data is stored per project
- derive funnel and SEO visualisations from the active project rows with sensible fallbacks

## Testing
- npm run build *(fails: Rollup failed to resolve import "react-router-dom" from src/main.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fa15644c83288ea945216ffe8ce0