### PR TITLE
Add sheet page for viewing recorded keywords

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import TotalsPanel from './components/TotalsPanel.jsx';
 import SheetModal from './components/SheetModal.jsx';
 import FunnelStages from './components/FunnelStages.jsx';
 import SeoOpportunity from './components/SeoOpportunity.jsx';
+import SheetView from './components/SheetView.jsx';
 import LogoutButton from './components/LogoutButton.jsx';
 import { KEYWORD_SHEET_ROWS } from './data/keywordSheet.js';
 import { DASHBOARD_DATA, TIMEFRAME_OPTIONS } from './data/dashboardData.js';
@@ -79,6 +80,10 @@ const App = () => {
       seo: {
         title: 'SEO Opportunity',
         subtitle: 'Map high-potential keywords to focus your optimisation efforts.',
+      },
+      sheet: {
+        title: 'Sheet',
+        subtitle: 'Browse the saved keyword rows for the active project.',
       },
     }),
     []
@@ -224,6 +229,7 @@ const App = () => {
     { id: 'overview', label: 'Overview' },
     { id: 'funnel', label: 'Funnel Stages' },
     { id: 'seo', label: 'SEO Opportunity' },
+    { id: 'sheet', label: 'Sheet' },
   ];
 
   const activeProjectRows = projectSheets[activeProject] || [];
@@ -256,6 +262,14 @@ const App = () => {
       return (
         <main className="funnel-layout">
           <SeoOpportunity rows={activeProjectRows} />
+        </main>
+      );
+    }
+
+    if (activePage === 'sheet') {
+      return (
+        <main className="funnel-layout">
+          <SheetView rows={activeProjectRows} />
         </main>
       );
     }
@@ -325,7 +339,7 @@ const App = () => {
                 {!user ? <span className="project-switcher__hint">Veuillez vous connecter</span> : null}
               </div>
             </div>
-            {activePage === 'overview' ? (
+            {activePage === 'overview' || activePage === 'sheet' || activePage === 'seo' ? (
               <>
                 <button type="button" className="sheet-trigger" onClick={() => setIsSheetOpen(true)}>
                   Sheet

--- a/src/components/SheetView.jsx
+++ b/src/components/SheetView.jsx
@@ -1,0 +1,164 @@
+import PropTypes from 'prop-types';
+
+const COLUMNS = [
+  { key: 'primaryKeyword', label: 'Primary keyword' },
+  { key: 'secondaryKeyword', label: 'Secondary keyword' },
+  { key: 'volume', label: 'Volume', align: 'right', type: 'number' },
+  { key: 'difficulty', label: 'Difficulty', align: 'right', type: 'number' },
+  { key: 'ws', label: 'W.S.', align: 'right', type: 'number' },
+  { key: 'intent', label: 'Intent' },
+  { key: 'funnelStage', label: 'Funnel stage' },
+  { key: 'win', label: 'Win %', align: 'right', type: 'percentage' },
+  { key: 'page', label: 'Page' },
+];
+
+const formatNumber = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  const numeric = Number(value);
+  if (Number.isFinite(numeric)) {
+    return numeric.toLocaleString('en-US');
+  }
+
+  return value.toString();
+};
+
+const formatPercentage = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  const raw = typeof value === 'string' ? value.trim() : value;
+  if (raw === '') {
+    return '—';
+  }
+
+  const cleaned = typeof raw === 'string' ? raw.replace(/%/g, '').replace(',', '.').trim() : raw;
+  const numeric = Number.parseFloat(cleaned);
+
+  if (Number.isFinite(numeric)) {
+    return `${numeric}%`;
+  }
+
+  return raw.toString();
+};
+
+const formatCellValue = (row, column) => {
+  const value = row?.[column.key];
+
+  if (column.type === 'number') {
+    return formatNumber(value);
+  }
+
+  if (column.type === 'percentage') {
+    return formatPercentage(value);
+  }
+
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  return value;
+};
+
+const SheetView = ({ rows }) => {
+  const safeRows = Array.isArray(rows) ? rows : [];
+  const totalVolume = safeRows.reduce((sum, row) => {
+    const numeric = Number(row?.volume);
+    if (!Number.isFinite(numeric)) {
+      return sum;
+    }
+    return sum + numeric;
+  }, 0);
+
+  const averageDifficulty = safeRows.length
+    ? Math.round(
+        safeRows.reduce((sum, row) => {
+          const numeric = Number(row?.difficulty);
+          if (!Number.isFinite(numeric)) {
+            return sum;
+          }
+          return sum + numeric;
+        }, 0) / safeRows.length
+      )
+    : 0;
+
+  return (
+    <section className="card sheet-view-card" aria-labelledby="sheet-view-title">
+      <header className="card__header sheet-view-card__header">
+        <div>
+          <p className="card__eyebrow">Recorded keywords</p>
+          <h2 id="sheet-view-title">Keyword sheet overview</h2>
+          <p className="card__subtitle">
+            Review the keywords currently stored for this project. Open the sheet to edit or add new entries.
+          </p>
+        </div>
+        <div className="sheet-view-card__summary" aria-live="polite">
+          <div>
+            <span className="sheet-view-card__summary-label">Total rows</span>
+            <span className="sheet-view-card__summary-value">{safeRows.length}</span>
+          </div>
+          <div>
+            <span className="sheet-view-card__summary-label">Total volume</span>
+            <span className="sheet-view-card__summary-value">{formatNumber(totalVolume)}</span>
+          </div>
+          <div>
+            <span className="sheet-view-card__summary-label">Avg. difficulty</span>
+            <span className="sheet-view-card__summary-value">{safeRows.length ? averageDifficulty : '—'}</span>
+          </div>
+        </div>
+      </header>
+
+      <div className="sheet-view-table" role="region" aria-live="polite" aria-label="Recorded keyword rows">
+        {safeRows.length ? (
+          <div className="sheet-view-table__scroll">
+            <table className="sheet-view-table__table">
+              <thead>
+                <tr>
+                  {COLUMNS.map((column) => (
+                    <th key={column.key} className={column.align ? `sheet-view-table__cell--${column.align}` : ''}>
+                      {column.label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {safeRows.map((row) => (
+                  <tr key={row.id || row.primaryKeyword}>
+                    {COLUMNS.map((column) => (
+                      <td
+                        key={column.key}
+                        className={column.align ? `sheet-view-table__cell--${column.align}` : ''}
+                      >
+                        {formatCellValue(row, column)}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="sheet-view-table__empty">No keywords recorded yet. Add entries via the sheet to see them here.</p>
+        )}
+      </div>
+    </section>
+  );
+};
+
+SheetView.propTypes = {
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string,
+      primaryKeyword: PropTypes.string,
+    })
+  ),
+};
+
+SheetView.defaultProps = {
+  rows: [],
+};
+
+export default SheetView;

--- a/src/index.css
+++ b/src/index.css
@@ -1017,6 +1017,98 @@ body {
   outline: none;
 }
 
+.sheet-view-card {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.sheet-view-card__header {
+  align-items: center;
+}
+
+.sheet-view-card__summary {
+  display: flex;
+  gap: 1.5rem;
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 12px 28px rgba(107, 91, 255, 0.18);
+}
+
+.sheet-view-card__summary > div {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.sheet-view-card__summary-label {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.sheet-view-card__summary-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-strong);
+}
+
+.sheet-view-table {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.sheet-view-table__scroll {
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 20px 45px rgba(107, 91, 255, 0.18);
+  overflow: auto;
+  max-height: 520px;
+}
+
+.sheet-view-table__table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+.sheet-view-table__table thead {
+  position: sticky;
+  top: 0;
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(6px);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+  z-index: 1;
+}
+
+.sheet-view-table__table th,
+.sheet-view-table__table td {
+  padding: 0.85rem 1.2rem;
+  font-size: 0.95rem;
+  text-align: left;
+  color: var(--text-strong);
+  border-bottom: 1px solid rgba(107, 91, 255, 0.15);
+}
+
+.sheet-view-table__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.sheet-view-table__table tbody tr:nth-child(even) {
+  background: rgba(107, 91, 255, 0.05);
+}
+
+.sheet-view-table__cell--right {
+  text-align: right;
+}
+
+.sheet-view-table__empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
 .figure {
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
## Summary
- add a Sheet page to the dashboard navigation and metadata
- create a SheetView card that lists recorded keyword rows with basic metrics
- style the new sheet table and expose the sheet modal trigger on more pages

## Testing
- npm run build *(fails: missing dev dependency react-router-dom in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ff7c21a48328933092316b5c6564