### PR TITLE
Remove funnel header timeline and sheet metadata

### DIFF
--- a/src/components/FunnelStages.jsx
+++ b/src/components/FunnelStages.jsx
@@ -250,10 +250,6 @@ const computeSankeyNodes = (definitions, links) => {
 };
 
 const FunnelStages = ({ timeframeOptions, activeTimeframe, onTimeframeChange, rows }) => {
-  const activeOption = timeframeOptions.find((option) => option.id === activeTimeframe);
-  const timeframeName = activeOption ? activeOption.name : 'Overview';
-  const timeframeLabel = activeOption ? activeOption.label : '';
-
   const { nodes: sankeyNodes, links: sankeyLinks, clusterTotals, stageTotals } = useMemo(
     () => buildFunnelDataset(rows && rows.length > 0 ? rows : KEYWORD_SHEET_ROWS),
     [rows]
@@ -272,12 +268,7 @@ const FunnelStages = ({ timeframeOptions, activeTimeframe, onTimeframeChange, ro
     <section className="card funnel-card" aria-labelledby="funnel-title">
       <header className="funnel-card__header">
         <div className="funnel-card__header-block">
-          <span className="card__eyebrow">Timeline</span>
           <TimeFilter options={timeframeOptions} activeId={activeTimeframe} onSelect={onTimeframeChange} />
-        </div>
-        <div className="funnel-card__header-meta" aria-live="polite">
-          <span className="funnel-card__meta-label">{timeframeName}</span>
-          <span className="funnel-card__meta-value">{timeframeLabel}</span>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- remove the timeline eyebrow text and associated metadata from the funnel stages header
- keep the timeframe selector while simplifying the header layout

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173 *(fails: missing dependency react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68d80391d08c83288d5b4067404f9f87