### PR TITLE
Add Supabase keyword API and client helpers

### DIFF
--- a/app/api/projects/[projectId]/keywords/route.ts
+++ b/app/api/projects/[projectId]/keywords/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse, type NextRequest } from 'next/server';
+import { getSupabaseServerClient } from '../../../../../supabaseServer';
+
+type RouteParams = {
+  params: {
+    projectId?: string;
+  };
+};
+
+type KeywordPayload = {
+  project_id: string;
+  keyword: string;
+  keyword_normalized: string;
+};
+
+type NormalizedKeyword = Omit<KeywordPayload, 'project_id'>;
+
+const normalizeKeyword = (value: unknown): NormalizedKeyword | null => {
+  if (typeof value !== 'string' && typeof value !== 'number') {
+    return null;
+  }
+
+  const keyword = value
+    .toString()
+    .trim()
+    .replace(/\s+/g, ' ');
+
+  if (!keyword) {
+    return null;
+  }
+
+  return {
+    keyword,
+    keyword_normalized: keyword.toLowerCase(),
+  };
+};
+
+export const POST = async (request: NextRequest, { params }: RouteParams) => {
+  const projectId = params.projectId;
+
+  if (!projectId) {
+    return NextResponse.json({ ok: false, error: 'Missing projectId in route parameters.' }, { status: 400 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON payload.' }, { status: 400 });
+  }
+
+  const keywordsInput = (body as { keywords?: unknown }).keywords;
+  if (keywordsInput != null && !Array.isArray(keywordsInput)) {
+    return NextResponse.json({ ok: false, error: 'The "keywords" field must be an array.' }, { status: 400 });
+  }
+
+  const rawKeywords = Array.isArray(keywordsInput) ? keywordsInput : [];
+
+  const supabase = getSupabaseServerClient();
+
+  const { data: project, error: projectError } = await supabase
+    .from('projects')
+    .select('id')
+    .eq('id', projectId)
+    .maybeSingle();
+
+  if (projectError) {
+    return NextResponse.json(
+      { ok: false, error: projectError.message || 'Unable to verify project existence.' },
+      { status: 500 }
+    );
+  }
+
+  if (!project) {
+    return NextResponse.json({ ok: false, error: 'Project not found.' }, { status: 404 });
+  }
+
+  const seen = new Set<string>();
+  const rows: KeywordPayload[] = [];
+
+  for (const entry of rawKeywords) {
+    const normalized = normalizeKeyword(entry);
+    if (!normalized) continue;
+
+    if (seen.has(normalized.keyword_normalized)) continue;
+    seen.add(normalized.keyword_normalized);
+
+    rows.push({
+      project_id: projectId,
+      ...normalized,
+    });
+  }
+
+  if (rows.length === 0) {
+    return NextResponse.json({ ok: true, inserted: 0 });
+  }
+
+  const { data, error } = await supabase
+    .from('keywords')
+    .insert(rows, { ignoreDuplicates: true })
+    .select('id');
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message || 'Unable to insert keywords.' }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true, inserted: data?.length ?? 0 });
+};

--- a/src/services/keywordsClient.ts
+++ b/src/services/keywordsClient.ts
@@ -1,0 +1,77 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL must be defined to use the Supabase client.');
+}
+
+if (!supabaseAnonKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_ANON_KEY must be defined to use the Supabase client.');
+}
+
+let browserClient: SupabaseClient | null = null;
+
+const getBrowserClient = (): SupabaseClient => {
+  if (!browserClient) {
+    browserClient = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+      },
+    });
+  }
+
+  return browserClient;
+};
+
+export type KeywordRecord = {
+  id: string;
+  keyword: string;
+  created_at: string;
+};
+
+export const saveKeywordsViaAPI = async (projectId: string, keywords: unknown[]): Promise<number> => {
+  if (!projectId) {
+    throw new Error('projectId is required to save keywords.');
+  }
+
+  const response = await fetch(`/api/projects/${encodeURIComponent(projectId)}/keywords`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ keywords }),
+  });
+
+  const payload = (await response.json().catch(() => null)) as
+    | { ok: boolean; error?: string; inserted?: number }
+    | null;
+
+  if (!response.ok || !payload?.ok) {
+    const errorMessage = payload?.error || 'Unable to save keywords via API.';
+    throw new Error(errorMessage);
+  }
+
+  return payload.inserted ?? 0;
+};
+
+export const fetchKeywords = async (projectId: string): Promise<KeywordRecord[]> => {
+  if (!projectId) {
+    throw new Error('projectId is required to fetch keywords.');
+  }
+
+  const supabase = getBrowserClient();
+  const { data, error } = await supabase
+    .from('keywords')
+    .select('id, keyword, created_at')
+    .eq('project_id', projectId)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message || 'Unable to fetch keywords.');
+  }
+
+  return data ?? [];
+};

--- a/supabaseServer.ts
+++ b/supabaseServer.ts
@@ -1,0 +1,29 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL must be defined to create the service Supabase client.');
+}
+
+if (!serviceRoleKey) {
+  throw new Error('SUPABASE_SERVICE_ROLE_KEY must be defined to create the service Supabase client.');
+}
+
+let cachedClient: SupabaseClient | null = null;
+
+export const getSupabaseServerClient = (): SupabaseClient => {
+  if (!cachedClient) {
+    cachedClient = createClient(supabaseUrl, serviceRoleKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+      },
+    });
+  }
+
+  return cachedClient;
+};
+
+export type { SupabaseClient };


### PR DESCRIPTION
## Summary
- add a dedicated Supabase service-role client for secure server-side access
- implement an API route to normalise and upsert project keywords with duplicate protection
- expose client helpers to persist Supabase sessions and call the new API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8df685b8883288599577e16a491b8