### PR TITLE
Add a project deletion button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -206,6 +206,16 @@ body {
   outline: none;
 }
 
+.project-switcher__button--danger {
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  box-shadow: 0 12px 25px rgba(239, 68, 68, 0.35);
+}
+
+.project-switcher__button--danger:hover,
+.project-switcher__button--danger:focus-visible {
+  box-shadow: 0 16px 32px rgba(239, 68, 68, 0.45);
+}
+
 .project-switcher__button:disabled {
   opacity: 0.6;
   cursor: not-allowed;

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -110,3 +110,23 @@ export const createProject = async ({ name, description, owner = null }) => {
     created_at: data.created_at ?? null,
   };
 };
+
+export const deleteProject = async (id) => {
+  if (!id) {
+    throw new Error("L'identifiant du projet est requis pour la suppression.");
+  }
+
+  if (!isSupabaseConfigured) {
+    // Aucun appel distant possible, on considère la suppression comme réussie côté local.
+    return { skipped: true };
+  }
+
+  const supabase = await getSupabaseClient();
+  const { error } = await supabase.from('projects').delete().eq('id', id);
+
+  if (error) {
+    throw new Error(error.message || 'Impossible de supprimer le projet.');
+  }
+
+  return { success: true };
+};


### PR DESCRIPTION
## Summary
- add a Supabase-backed helper to delete projects when available
- expose a delete project action in the dashboard with optimistic updates and toast feedback
- style a danger variant of the project switcher button for the new action

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d952e1de4083289e50425bdcf2d460