### PR TITLE
Replace project delete button with trash icon

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -422,19 +422,51 @@ const App = () => {
               <label className="project-switcher__label" htmlFor="project-selector">
                 Projet
               </label>
-              <select
-                id="project-selector"
-                className="project-switcher__select"
-                value={activeProject}
-                onChange={(event) => setActiveProject(event.target.value)}
-                disabled={isProjectLoading || projects.length === 0}
-              >
-                {projects.map((project) => (
-                  <option key={project.id} value={project.id}>
-                    {project.label}
-                  </option>
-                ))}
-              </select>
+              <div className="project-switcher__control">
+                <select
+                  id="project-selector"
+                  className="project-switcher__select"
+                  value={activeProject}
+                  onChange={(event) => setActiveProject(event.target.value)}
+                  disabled={isProjectLoading || projects.length === 0}
+                >
+                  {projects.map((project) => (
+                    <option key={project.id} value={project.id}>
+                      {project.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  className="project-switcher__icon-button"
+                  onClick={handleProjectDelete}
+                  aria-label="Supprimer le projet"
+                  disabled={
+                    isProjectLoading ||
+                    isProjectDeleting ||
+                    projects.length === 0 ||
+                    !activeProject
+                  }
+                >
+                  <svg
+                    className="project-switcher__icon"
+                    width="20"
+                    height="20"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                  >
+                    <path
+                      d="M9 3.75h6m-9 3h12M10.5 10.5v6m3-6v6M5.25 6.75 6 19.5c.063 1.05.938 1.875 1.988 1.875h8.024c1.05 0 1.925-.825 1.988-1.875L18.75 6.75"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              </div>
               <div className="project-switcher__actions">
                 <button
                   type="button"
@@ -443,19 +475,6 @@ const App = () => {
                   disabled={isProjectLoading || !user}
                 >
                   Nouveau projet
-                </button>
-                <button
-                  type="button"
-                  className="project-switcher__button project-switcher__button--danger"
-                  onClick={handleProjectDelete}
-                  disabled={
-                    isProjectLoading ||
-                    isProjectDeleting ||
-                    projects.length === 0 ||
-                    !activeProject
-                  }
-                >
-                  Supprimer le projet
                 </button>
                 {!user ? <span className="project-switcher__hint">Veuillez vous connecter</span> : null}
               </div>

--- a/src/index.css
+++ b/src/index.css
@@ -182,8 +182,51 @@ body {
   cursor: pointer;
 }
 
+.project-switcher__control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.2rem 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.75);
+}
+
 .project-switcher__select::-ms-expand {
   display: none;
+}
+
+.project-switcher__icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #f87171, #ef4444);
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 10px 22px rgba(239, 68, 68, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.project-switcher__icon-button:hover,
+.project-switcher__icon-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(239, 68, 68, 0.45);
+  outline: none;
+}
+
+.project-switcher__icon-button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.project-switcher__icon {
+  width: 1.05rem;
+  height: 1.05rem;
 }
 
 .project-switcher__button {
@@ -204,16 +247,6 @@ body {
   transform: translateY(-1px);
   box-shadow: 0 16px 32px rgba(122, 106, 255, 0.4);
   outline: none;
-}
-
-.project-switcher__button--danger {
-  background: linear-gradient(135deg, #f87171, #ef4444);
-  box-shadow: 0 12px 25px rgba(239, 68, 68, 0.35);
-}
-
-.project-switcher__button--danger:hover,
-.project-switcher__button--danger:focus-visible {
-  box-shadow: 0 16px 32px rgba(239, 68, 68, 0.45);
 }
 
 .project-switcher__button:disabled {


### PR DESCRIPTION
## Summary
- replace the project deletion button with a trash icon positioned beside the project selector for quicker access
- add styles for the new icon button and control wrapper while removing the unused danger button styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9547206ac8328b2d777b8a63e1bc5