### PR TITLE
Fix funnel stage chart clipping

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -344,7 +344,7 @@ body {
 .funnel-card {
   padding: 2.4rem 2.7rem;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   width: 100%;
 }
 
@@ -555,6 +555,7 @@ body {
   filter: blur(90px);
   opacity: 0.45;
   pointer-events: none;
+  clip-path: inset(0 round var(--radius));
 }
 
 .funnel-card::before {


### PR DESCRIPTION
## Summary
- allow the funnel card container to show the complete Sankey chart without clipping
- clip the decorative glow pseudo-elements so the visual treatment stays within the card bounds

## Testing
- npm run dev -- --host 0.0.0.0 --port 4173

------
https://chatgpt.com/codex/tasks/task_e_68d958a75c548328a4c2b656f009f78d