### PR TITLE
Increase Sankey chart height dynamically

### DIFF
--- a/src/components/FunnelStages.jsx
+++ b/src/components/FunnelStages.jsx
@@ -281,6 +281,19 @@ const FunnelStages = ({ rows }) => {
 
   const leftNodes = useMemo(() => sankeyNodes.filter((node) => node.side === 'left'), [sankeyNodes]);
   const rightNodes = useMemo(() => sankeyNodes.filter((node) => node.side === 'right'), [sankeyNodes]);
+  const sankeyHeight = useMemo(() => {
+    const baseHeight = 420;
+    const baselineNodeCount = 8;
+    const extraHeightPerNode = 42;
+
+    const maxNodeCount = Math.max(leftNodes.length, rightNodes.length);
+
+    if (maxNodeCount <= baselineNodeCount) {
+      return baseHeight;
+    }
+
+    return baseHeight + (maxNodeCount - baselineNodeCount) * extraHeightPerNode;
+  }, [leftNodes.length, rightNodes.length]);
   const stageKeywordHighlights = useMemo(
     () => buildStageKeywordHighlights(rows && rows.length > 0 ? rows : KEYWORD_SHEET_ROWS),
     [rows]
@@ -303,6 +316,7 @@ const FunnelStages = ({ rows }) => {
             valueFormatter={formatVolume}
             title="Répartition des volumes par stage"
             description="Flux des volumes de recherche entre les clusters de mots-clés et les étapes du funnel."
+            height={sankeyHeight}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- calculate the Sankey chart height based on the number of funnel nodes so labels have enough room
- pass the computed height into the chart to render all funnel information without clipping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d96881276c8328b07ac2b14aafbbf1