### PR TITLE
Replace new project UI labels with plus sign

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -473,8 +473,10 @@ const App = () => {
                   className="project-switcher__button"
                   onClick={() => setIsNewProjectOpen(true)}
                   disabled={isProjectLoading || !user}
+                  aria-label="Créer un nouveau projet"
                 >
-                  Nouveau projet
+                  <span aria-hidden="true">+</span>
+                  <span className="sr-only">Créer un nouveau projet</span>
                 </button>
                 {!user ? <span className="project-switcher__hint">Veuillez vous connecter</span> : null}
               </div>

--- a/src/components/NewProjectModal.jsx
+++ b/src/components/NewProjectModal.jsx
@@ -192,7 +192,10 @@ const NewProjectModal = ({ open, onRequestClose, onSubmit }) => {
       >
         <header className="new-project-modal__header">
           <div>
-            <h2 id="new-project-modal-title">Nouveau projet</h2>
+            <h2 id="new-project-modal-title">
+              <span aria-hidden="true">+</span>
+              <span className="sr-only">Nouveau projet</span>
+            </h2>
             <p>Créez un nouveau projet pour votre tableau de bord.</p>
           </div>
           <button


### PR DESCRIPTION
## Summary
- replace the project creation trigger text with a plus sign while keeping screen reader guidance
- update the new project modal title to present a plus sign with hidden accessible text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9706d70088328b1cc777321faf27f