### PR TITLE
Color sources cards by dominant funnel stage

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -772,6 +772,19 @@ body {
   letter-spacing: 0.05em;
 }
 
+.funnel-stage-card__stage {
+  align-self: flex-start;
+  margin-top: 0.1rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.16);
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .funnel-stage-card__value {
   font-size: 1.35rem;
   font-weight: 700;


### PR DESCRIPTION
## Summary
- determine the dominant funnel stage for each source cluster using keyword counts with volume as a tiebreaker
- apply the matching funnel stage gradient and badge to source cards while preserving fallbacks when no stage dominates
- style the new stage badge for clarity in the Sources summary

## Testing
- npm run build *(fails: vite not found because dependencies cannot be installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d97612a76c8328b97a9f8a94758289