### PR TITLE
feat: show quick wins in sheet overview

### DIFF
--- a/src/components/SheetModal.jsx
+++ b/src/components/SheetModal.jsx
@@ -4,23 +4,19 @@ import PropTypes from 'prop-types';
 import { classifyKeywordIntents, hasIntentClassificationCredentials } from '../services/intentClassification';
 import { saveKeywords } from '../services/keywords.js';
 import QuickWinIcon from './QuickWinIcon.jsx';
+import {
+  FW_VALUE_BY_LABEL,
+  getFwNumericValue,
+  meetsQuickWinCriteria,
+  resolveWinDisplayValue,
+  getWinSortValue,
+} from '../utils/quickWin.js';
 
 const ROW_HEIGHT = 60;
 const PAGE_SIZE_OPTIONS = [25, 50, 100];
 const INTENT_OPTIONS = ['Informational', 'Commercial', 'Transactional', 'Navigational'];
 const FUNNEL_OPTIONS = ['Awareness', 'Consideration', 'Decision'];
 const FW_OPTIONS = ['Low', 'Medium', 'High'];
-const FW_VALUE_BY_LABEL = {
-  Low: 1.0,
-  Medium: 1.5,
-  High: 2.0,
-};
-const QUICK_WIN_RULES = {
-  minWs: 20,
-  maxDifficulty: 20,
-  minFw: 1.5,
-  allowedIntents: new Set(['Commercial', 'Transactional']),
-};
 const FUNNEL_STAGE_TO_FW_LABEL = {
   Awareness: 'Low',
   Consideration: 'Medium',
@@ -265,94 +261,9 @@ const resolveFunnelWeight = (stage, rawFw) => {
   return { label: DEFAULT_FW_LABEL, value: DEFAULT_FW_VALUE };
 };
 
-const resolveFwNumericValue = (label, explicitValue) => {
-  if (explicitValue !== undefined && explicitValue !== null) {
-    return explicitValue;
-  }
-  if (label && FW_VALUE_BY_LABEL[label] !== undefined) {
-    return FW_VALUE_BY_LABEL[label];
-  }
-  return null;
-};
-
-const getFwNumericValue = (row) => {
-  if (!row) {
-    return null;
-  }
-  return resolveFwNumericValue(row.fw, row.fwValue);
-};
-
 const getFwDisplayValue = (row) => {
   const numeric = getFwNumericValue(row);
   return numeric !== null ? numeric.toFixed(1) : '';
-};
-
-const meetsQuickWinCriteria = (row) => {
-  if (!row) {
-    return false;
-  }
-
-  const ws = Number(row.ws ?? 0);
-  const difficulty = Number(row.difficulty ?? 0);
-  const fwNumeric = Number(getFwNumericValue(row) ?? 0);
-  const intent = row.intent || '';
-
-  return (
-    ws > QUICK_WIN_RULES.minWs &&
-    difficulty <= QUICK_WIN_RULES.maxDifficulty &&
-    fwNumeric >= QUICK_WIN_RULES.minFw &&
-    QUICK_WIN_RULES.allowedIntents.has(intent)
-  );
-};
-
-const resolveWinDisplayValue = (row, { includePercentSymbol = true } = {}) => {
-  if (!row) {
-    return { text: '', quickWin: false, numeric: null };
-  }
-
-  if (row.quickWin) {
-    return { text: 'Quick win', quickWin: true, numeric: null };
-  }
-
-  const rawValue = row.win;
-  if (rawValue === '' || rawValue === null || rawValue === undefined) {
-    return { text: '', quickWin: false, numeric: null };
-  }
-
-  const numericValue =
-    typeof rawValue === 'number' && Number.isFinite(rawValue)
-      ? rawValue
-      : (() => {
-          const parsed = Number.parseFloat(rawValue);
-          return Number.isFinite(parsed) ? parsed : null;
-        })();
-
-  const baseText = numericValue !== null ? numericValue.toString() : rawValue.toString();
-  const text = includePercentSymbol ? `${baseText}%` : baseText;
-
-  return { text, quickWin: false, numeric: numericValue };
-};
-
-const getWinSortValue = (row) => {
-  if (!row) {
-    return Number.NEGATIVE_INFINITY;
-  }
-
-  if (row.quickWin) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  const rawValue = row.win;
-  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
-    return rawValue;
-  }
-
-  if (rawValue === '' || rawValue === null || rawValue === undefined) {
-    return Number.NEGATIVE_INFINITY;
-  }
-
-  const parsed = Number.parseFloat(rawValue);
-  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
 };
 
 const computeWsScore = (row) => {

--- a/src/components/SheetView.jsx
+++ b/src/components/SheetView.jsx
@@ -1,5 +1,7 @@
 import PropTypes from 'prop-types';
 
+import { resolveWinDisplayValue } from '../utils/quickWin.js';
+
 const COLUMNS = [
   { key: 'primaryKeyword', label: 'Primary keyword' },
   { key: 'secondaryKeyword', label: 'Secondary keyword' },
@@ -46,6 +48,11 @@ const formatPercentage = (value) => {
 };
 
 const formatCellValue = (row, column) => {
+  if (column.key === 'win') {
+    const displayValue = resolveWinDisplayValue(row);
+    return displayValue.text || '—';
+  }
+
   const value = row?.[column.key];
 
   if (column.type === 'number') {

--- a/src/utils/quickWin.js
+++ b/src/utils/quickWin.js
@@ -1,0 +1,122 @@
+const FW_VALUE_BY_LABEL = {
+  Low: 1.0,
+  Medium: 1.5,
+  High: 2.0,
+};
+
+const QUICK_WIN_RULES = {
+  minWs: 20,
+  maxDifficulty: 20,
+  minFw: 1.5,
+  allowedIntents: new Set(['Commercial', 'Transactional']),
+};
+
+const toFiniteNumber = (value) => {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+
+  const numeric = typeof value === 'number' ? value : Number.parseFloat(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
+const resolveFwNumericValue = (label, explicitValue) => {
+  const explicitNumeric = toFiniteNumber(explicitValue);
+  if (explicitNumeric !== null) {
+    return explicitNumeric;
+  }
+
+  if (label && Object.prototype.hasOwnProperty.call(FW_VALUE_BY_LABEL, label)) {
+    return FW_VALUE_BY_LABEL[label];
+  }
+
+  return null;
+};
+
+const getFwNumericValue = (row) => {
+  if (!row) {
+    return null;
+  }
+
+  return resolveFwNumericValue(row.fw, row.fwValue);
+};
+
+const meetsQuickWinCriteria = (row) => {
+  if (!row) {
+    return false;
+  }
+
+  const ws = Number(row.ws ?? 0);
+  const difficulty = Number(row.difficulty ?? 0);
+  const fwNumeric = Number(getFwNumericValue(row) ?? 0);
+  const intent = row.intent || '';
+
+  return (
+    ws > QUICK_WIN_RULES.minWs &&
+    difficulty <= QUICK_WIN_RULES.maxDifficulty &&
+    fwNumeric >= QUICK_WIN_RULES.minFw &&
+    QUICK_WIN_RULES.allowedIntents.has(intent)
+  );
+};
+
+const resolveWinDisplayValue = (row, { includePercentSymbol = true } = {}) => {
+  if (!row) {
+    return { text: '', quickWin: false, numeric: null };
+  }
+
+  const isQuickWin = row.quickWin ?? meetsQuickWinCriteria(row);
+  if (isQuickWin) {
+    return { text: 'Quick win', quickWin: true, numeric: null };
+  }
+
+  const rawValue = row.win;
+  if (rawValue === '' || rawValue === null || rawValue === undefined) {
+    return { text: '', quickWin: false, numeric: null };
+  }
+
+  const numericValue =
+    typeof rawValue === 'number' && Number.isFinite(rawValue)
+      ? rawValue
+      : (() => {
+          const parsed = Number.parseFloat(rawValue);
+          return Number.isFinite(parsed) ? parsed : null;
+        })();
+
+  const baseText = numericValue !== null ? numericValue.toString() : rawValue.toString();
+  const text = includePercentSymbol ? `${baseText}%` : baseText;
+
+  return { text, quickWin: false, numeric: numericValue };
+};
+
+const getWinSortValue = (row) => {
+  if (!row) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const isQuickWin = row.quickWin ?? meetsQuickWinCriteria(row);
+  if (isQuickWin) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  const rawValue = row.win;
+  if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+    return rawValue;
+  }
+
+  if (rawValue === '' || rawValue === null || rawValue === undefined) {
+    return Number.NEGATIVE_INFINITY;
+  }
+
+  const parsed = Number.parseFloat(rawValue);
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+};
+
+export {
+  FW_VALUE_BY_LABEL,
+  QUICK_WIN_RULES,
+  resolveFwNumericValue,
+  getFwNumericValue,
+  meetsQuickWinCriteria,
+  resolveWinDisplayValue,
+  getWinSortValue,
+};


### PR DESCRIPTION
## Summary
- extract quick win rules and helpers into a shared utility
- reuse the shared helpers in the sheet modal to keep calculations consistent
- update the sheet overview table so the Win column renders the "Quick win" label when applicable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d978b40c7883289a2ea47061e9cad6