### PR TITLE
Add axes grid and labels to SEO Opportunity chart

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -401,6 +401,30 @@ body {
   display: block;
 }
 
+.seo-bubble-chart__grid-line {
+  stroke: rgba(15, 23, 42, 0.08);
+  stroke-dasharray: 4 6;
+}
+
+.seo-bubble-chart__axis {
+  stroke: rgba(15, 23, 42, 0.18);
+  stroke-width: 1.5;
+}
+
+.seo-bubble-chart__axis-label {
+  fill: var(--text-soft);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.seo-bubble-chart__tick-label {
+  fill: var(--text-muted);
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
 .seo-bubble-chart__caption {
   margin: 1.4rem 0 0;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- capture layout metadata for the SEO Opportunity chart so axis dimensions are available
- render grid lines plus labelled X and Y axes to display WS and volume values on the SEO Opportunity page
- style the new chart annotations to match the dashboard design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d97ffd7d6883288728e8992aab5024