### PR TITLE
Show bubble names on hover

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -605,6 +605,7 @@ const SeoOpportunity = ({ rows }) => {
               const radius = radiusScale(keyword.ws);
               return (
                 <g key={keyword.id} transform={`translate(${keyword.x}, ${keyword.y})`} className="seo-bubble">
+                  <title>{keyword.topic || keyword.shortLabel || 'Keyword'}</title>
                   <circle
                     className="seo-bubble__circle"
                     r={radius}


### PR DESCRIPTION
## Summary
- add SVG titles to SEO opportunity bubbles so the keyword name appears on hover

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9841b712483289ca8468a35e8b68a