### PR TITLE
Ensure SEO funnel chart labels remain visible

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -12,11 +12,11 @@ const minRadius = 42;
 const maxRadius = 110;
 
 const stackedChartWidth = chartWidth;
-const stackedChartHeight = 360;
+const stackedChartHeight = 420;
 const stackedChartPadding = {
   top: 36,
   right: 48,
-  bottom: 96,
+  bottom: 144,
   left: 96,
 };
 


### PR DESCRIPTION
## Summary
- enlarge the SEO opportunity stacked chart dimensions so x-axis labels can render without being cut off

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d991c301a483289bdfda75906f0468