### PR TITLE
Increase SEO funnel chart height

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -12,7 +12,7 @@ const minRadius = 42;
 const maxRadius = 110;
 
 const stackedChartWidth = chartWidth;
-const stackedChartHeight = 420;
+const stackedChartHeight = 560;
 const stackedChartPadding = {
   top: 36,
   right: 48,


### PR DESCRIPTION
## Summary
- increase the stacked funnel chart height on the SEO Opportunity page so all funnel stages remain visible across categories

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d993696da08328a2dba0b12ff1db38