### PR TITLE
Adjust SEO funnel axis label spacing

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -764,7 +764,7 @@ const SeoOpportunity = ({ rows }) => {
                   <text
                     className="seo-stacked-chart__axis-label"
                     x={stackedChartLeft + stackedChartInnerWidth / 2}
-                    y={stackedChartHeight - 32}
+                    y={stackedChartHeight - 12}
                     textAnchor="middle"
                   >
                     Keyword categories


### PR DESCRIPTION
## Summary
- lower the "Keyword categories" x-axis label on the funnel stage distribution chart so it no longer overlaps the rotated category names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da2e48915c8328a6367ff73b010cc3