### PR TITLE
Adjust SEO funnel axis label spacing

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -764,7 +764,7 @@ const SeoOpportunity = ({ rows }) => {
                   <text
                     className="seo-stacked-chart__axis-label"
                     x={stackedChartLeft + stackedChartInnerWidth / 2}
-                    y={stackedChartHeight - 12}
+                    y={stackedChartHeight - 4}
                     textAnchor="middle"
                   >
                     Keyword categories


### PR DESCRIPTION
## Summary
- lower the "Keyword categories" axis label in the SEO funnel stacked chart to prevent overlap with category names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3180f98c832898d4a4ed6a3ffc3e