### PR TITLE
Set fixed viewBox for SEO stacked chart

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -804,7 +804,7 @@ const SeoOpportunity = ({ rows }) => {
             {stackedData.length ? (
               <svg
                 className="seo-stacked-chart__svg"
-                viewBox={`0 0 ${stackedChartWidth} ${stackedChartHeight}`}
+                viewBox="0 0 960 650"
                 preserveAspectRatio="xMidYMid meet"
                 role="presentation"
                 aria-hidden="true"


### PR DESCRIPTION
## Summary
- set the SEO opportunity stacked chart SVG to use a fixed 960x650 viewBox

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da5b21a7a48328adb67401d11b3a5f