### PR TITLE
Fix overflow in SEO pipeline overview column

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1079,7 +1079,13 @@ body {
   justify-content: space-between;
   align-items: flex-start;
   gap: 1.5rem;
+  flex-wrap: wrap;
   margin-bottom: 1.8rem;
+}
+
+.card__header > * {
+  min-width: 0;
+  flex-shrink: 1;
 }
 
 .card__header h2 {
@@ -2413,6 +2419,13 @@ body {
   font-size: 1.8rem;
   font-weight: 700;
   color: var(--text-strong);
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.35rem;
+  text-align: right;
+  max-width: 100%;
+  line-height: 1.2;
 }
 
 .earnings-list {
@@ -2431,6 +2444,7 @@ body {
   border-radius: 18px;
   padding: 0.75rem 1rem;
   font-size: 0.9rem;
+  column-gap: 0.75rem;
 }
 
 .earnings-list__label {
@@ -2446,6 +2460,9 @@ body {
 .earnings-list__trend {
   font-weight: 600;
   text-align: right;
+  justify-self: end;
+  max-width: 100%;
+  line-height: 1.2;
 }
 
 .totals-panel__footer {


### PR DESCRIPTION
## Summary
- wrap dashboard card headers so long labels stay within their columns
- constrain totals panel highlight and cluster rows so SEO overview content never overflows

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da77b1031c8328a2c4ce5dc0fad5c6