### PR TITLE
Fix readability of cluster trend entries

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2463,7 +2463,8 @@ body {
   justify-self: end;
   max-width: 100%;
   line-height: 1.2;
-  overflow-wrap: anywhere;
+  overflow-wrap: break-word;
+  word-break: normal;
 }
 
 .totals-panel__footer {


### PR DESCRIPTION
## Summary
- adjust the cluster trend text wrapping to avoid breaking words mid-letter in the totals panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da7a53ad488328848a4dd44731d88b