### PR TITLE
Refactor SEO overview layout for consolidated summary

### DIFF
--- a/src/components/OverviewSummary.jsx
+++ b/src/components/OverviewSummary.jsx
@@ -1,0 +1,262 @@
+import PropTypes from 'prop-types';
+
+const formatCount = (value) => new Intl.NumberFormat('fr-FR').format(Number(value) || 0);
+
+const OverviewSummary = ({ overview, performance, totals, sheet, onNavigate }) => {
+  const stageSummaries = Array.isArray(performance?.categories) ? performance.categories : [];
+  const opportunityList = Array.isArray(totals?.list) ? totals.list.slice(0, 4) : [];
+  const sheetSample = Array.isArray(sheet?.sample) ? sheet.sample : [];
+  const stageDistribution = Array.isArray(sheet?.stageDistribution) ? sheet.stageDistribution : [];
+
+  const handleNavigate = (pageId) => {
+    if (typeof onNavigate === 'function') {
+      onNavigate(pageId);
+    }
+  };
+
+  return (
+    <div className="overview-page">
+      <section className="card overview-page__intro" aria-labelledby="overview-intro-title">
+        <header className="overview-page__intro-header">
+          <div>
+            <p className="card__eyebrow">Vue d’ensemble du pipeline SEO</p>
+            <h2 id="overview-intro-title">{overview.title}</h2>
+            <p className="card__subtitle">{overview.subtitle}</p>
+          </div>
+          <div className="overview-page__cta-group" role="group" aria-label="Accès rapide aux sections détaillées">
+            <button type="button" className="pill-button" onClick={() => handleNavigate('funnel')}>
+              Explorer le tunnel
+            </button>
+            <button type="button" className="pill-button" onClick={() => handleNavigate('seo')}>
+              Voir les opportunités
+            </button>
+            <button type="button" className="pill-button" onClick={() => handleNavigate('sheet')}>
+              Ouvrir le tableur
+            </button>
+          </div>
+        </header>
+
+        <div className="overview-page__stats">
+          <div className="overview-page__stat">
+            <p className="overview-page__stat-label">{overview.quantity.label}</p>
+            <p className="overview-page__stat-value">{overview.quantity.value}</p>
+          </div>
+          <div className="overview-page__stat">
+            <p className="overview-page__stat-label">{overview.summary.label}</p>
+            <p className="overview-page__stat-value">{overview.summary.value}</p>
+            <p className={`trend trend--${overview.summary.trend.direction}`}>{overview.summary.trend.text}</p>
+          </div>
+          {overview.rows.slice(0, 4).map((row) => (
+            <div key={row.label} className="overview-page__stat overview-page__stat--compact">
+              <p className="overview-page__stat-label">{row.label}</p>
+              <p className="overview-page__stat-value">{row.value}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="overview-page__grid" aria-label="Synthèse des autres vues">
+        <article className="card overview-page__panel" aria-labelledby="overview-pipeline-title">
+          <header className="overview-page__panel-header">
+            <div>
+              <h3 id="overview-pipeline-title">Pipeline et entonnoir</h3>
+              <p className="card__subtitle">
+                {performance.centerValue} · {performance.datasets?.[0]?.total}
+              </p>
+            </div>
+            <button type="button" className="text-button" onClick={() => handleNavigate('funnel')}>
+              Accéder au détail
+            </button>
+          </header>
+          <p className="overview-page__panel-text">
+            Les mots-clés suivis couvrent l’ensemble du parcours : de la sensibilisation à la décision.
+            Utilisez le volet « Funnel Stages » pour visualiser les contenus et sujets par étape.
+          </p>
+          <ul className="overview-page__list">
+            {stageSummaries.map((stage) => (
+              <li key={stage.key} className="overview-page__list-item">
+                <span className="overview-page__list-label">{stage.label}</span>
+                <span className="overview-page__list-value">{stage.amount}</span>
+              </li>
+            ))}
+          </ul>
+        </article>
+
+        <article className="card overview-page__panel" aria-labelledby="overview-opportunity-title">
+          <header className="overview-page__panel-header">
+            <div>
+              <h3 id="overview-opportunity-title">Opportunités SEO à prioriser</h3>
+              <p className="card__subtitle">{totals.highlight?.value} · {totals.highlight?.trend?.text}</p>
+            </div>
+            <button type="button" className="text-button" onClick={() => handleNavigate('seo')}>
+              Voir la cartographie
+            </button>
+          </header>
+          <p className="overview-page__panel-text">
+            Retrouvez dans « SEO Opportunity » les sujets à fort impact classés par cluster. Les meilleures
+            pistes sont listées ci-dessous pour démarrer rapidement vos optimisations.
+          </p>
+          <ul className="overview-page__list">
+            {opportunityList.map((item) => (
+              <li key={item.label} className="overview-page__list-item">
+                <span className="overview-page__list-label">{item.label}</span>
+                <span className="overview-page__list-value">
+                  {item.value} · {item.trend?.text}
+                </span>
+              </li>
+            ))}
+          </ul>
+          {totals.footer && (
+            <footer className="overview-page__panel-footer">
+              <p className="overview-page__panel-footer-label">{totals.footer.label}</p>
+              <p className={`trend trend--${totals.footer.trend?.direction || 'neutral'}`}>
+                {totals.footer.value} · {totals.footer.trend?.text}
+              </p>
+            </footer>
+          )}
+        </article>
+      </section>
+
+      <section className="card overview-page__panel overview-page__sheet" aria-labelledby="overview-sheet-title">
+        <header className="overview-page__panel-header">
+          <div>
+            <h3 id="overview-sheet-title">Ce que révèle le tableur projet</h3>
+            <p className="card__subtitle">
+              {formatCount(sheet.totalKeywords)} mots-clés suivis · {formatCount(sheet.uniqueClusters)} clusters actifs
+            </p>
+          </div>
+          <button type="button" className="text-button" onClick={() => handleNavigate('sheet')}>
+            Consulter toutes les lignes
+          </button>
+        </header>
+        <p className="overview-page__panel-text">
+          Le tableur consolide les données opérationnelles utilisées dans les vues précédentes. Voici la
+          répartition actuelle des sujets et quelques exemples de priorités identifiées.
+        </p>
+        <div className="overview-page__sheet-grid">
+          <div>
+            <h4 className="overview-page__section-title">Répartition par étape</h4>
+            <ul className="overview-page__list">
+              {stageDistribution.map((stage) => (
+                <li key={stage.label} className="overview-page__list-item">
+                  <span className="overview-page__list-label">{stage.label}</span>
+                  <span className="overview-page__list-value">
+                    {formatCount(stage.count)} mots-clés · {stage.share}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h4 className="overview-page__section-title">Exemples à forte priorité</h4>
+            <ul className="overview-page__keyword-list">
+              {sheetSample.length === 0 && (
+                <li className="overview-page__keyword-empty">Aucune ligne enregistrée pour le moment.</li>
+              )}
+              {sheetSample.map((keyword) => (
+                <li key={keyword.primaryKeyword} className="overview-page__keyword-item">
+                  <span className="overview-page__keyword-term">{keyword.primaryKeyword}</span>
+                  <span className="overview-page__keyword-meta">
+                    {keyword.cluster} · {keyword.funnelStage} · {keyword.volume} recherches
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+OverviewSummary.propTypes = {
+  overview: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    subtitle: PropTypes.string.isRequired,
+    quantity: PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+    }).isRequired,
+    rows: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+    summary: PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.string.isRequired,
+      trend: PropTypes.shape({
+        direction: PropTypes.oneOf(['positive', 'negative', 'neutral']).isRequired,
+        text: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+  }).isRequired,
+  performance: PropTypes.shape({
+    centerValue: PropTypes.string,
+    categories: PropTypes.arrayOf(
+      PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        amount: PropTypes.string.isRequired,
+      })
+    ),
+    datasets: PropTypes.arrayOf(
+      PropTypes.shape({
+        total: PropTypes.string,
+      })
+    ),
+  }).isRequired,
+  totals: PropTypes.shape({
+    highlight: PropTypes.shape({
+      value: PropTypes.string,
+      trend: PropTypes.shape({
+        text: PropTypes.string,
+        direction: PropTypes.oneOf(['positive', 'negative', 'neutral']),
+      }),
+    }),
+    list: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        value: PropTypes.string.isRequired,
+        trend: PropTypes.shape({
+          text: PropTypes.string,
+        }),
+      })
+    ),
+    footer: PropTypes.shape({
+      label: PropTypes.string,
+      value: PropTypes.string,
+      trend: PropTypes.shape({
+        direction: PropTypes.oneOf(['positive', 'negative', 'neutral']),
+        text: PropTypes.string,
+      }),
+    }),
+  }).isRequired,
+  sheet: PropTypes.shape({
+    totalKeywords: PropTypes.number.isRequired,
+    uniqueClusters: PropTypes.number.isRequired,
+    stageDistribution: PropTypes.arrayOf(
+      PropTypes.shape({
+        label: PropTypes.string.isRequired,
+        count: PropTypes.number.isRequired,
+        share: PropTypes.string.isRequired,
+      })
+    ).isRequired,
+    sample: PropTypes.arrayOf(
+      PropTypes.shape({
+        primaryKeyword: PropTypes.string.isRequired,
+        cluster: PropTypes.string.isRequired,
+        funnelStage: PropTypes.string.isRequired,
+        volume: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+  onNavigate: PropTypes.func,
+};
+
+OverviewSummary.defaultProps = {
+  onNavigate: undefined,
+};
+
+export default OverviewSummary;

--- a/src/index.css
+++ b/src/index.css
@@ -1066,6 +1066,224 @@ body {
   gap: 2rem;
 }
 
+.overview-layout {
+  display: block;
+}
+
+.overview-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.overview-page__intro-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.overview-page__cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.overview-page__stats {
+  margin-top: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.overview-page__stat {
+  padding: 1rem;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.45);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 15px 35px rgba(88, 82, 162, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.overview-page__stat--compact {
+  padding: 0.85rem 1rem;
+  gap: 0.25rem;
+}
+
+.overview-page__stat-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.overview-page__stat-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--text-strong);
+  margin: 0;
+}
+
+.overview-page__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+}
+
+.overview-page__panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.overview-page__panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.overview-page__panel-text {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.5;
+}
+
+.overview-page__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.overview-page__list-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.95rem;
+}
+
+.overview-page__list-label {
+  color: var(--text-strong);
+  font-weight: 600;
+}
+
+.overview-page__list-value {
+  color: var(--text-muted);
+  text-align: right;
+}
+
+.text-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--primary);
+  font-weight: 600;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity 0.2s ease;
+}
+
+.text-button:hover,
+.text-button:focus-visible {
+  opacity: 0.75;
+  outline: none;
+}
+
+.overview-page__panel-footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.2);
+  padding-top: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.overview-page__panel-footer-label {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.overview-page__sheet {
+  gap: 1.5rem;
+}
+
+.overview-page__sheet-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.overview-page__section-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: var(--text-strong);
+}
+
+.overview-page__keyword-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.overview-page__keyword-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.38);
+  backdrop-filter: blur(10px);
+}
+
+.overview-page__keyword-term {
+  font-weight: 600;
+  color: var(--text-strong);
+}
+
+.overview-page__keyword-meta {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.overview-page__keyword-empty {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+@media (max-width: 960px) {
+  .overview-page__stats {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .overview-page__grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .overview-page__intro-header {
+    flex-direction: column;
+  }
+
+  .overview-page__cta-group {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .overview-page__cta-group .pill-button {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 .card {
   background: linear-gradient(145deg, var(--card-gradient-start), var(--card-gradient-end));
   border-radius: var(--radius);


### PR DESCRIPTION
## Summary
- replace the overview dashboard grid with a new summary component that highlights pipeline, SEO opportunities, and sheet insights
- derive project-level metrics (stage distribution, cluster count, keyword samples) for the overview page and expose quick navigation to detailed views
- style the refreshed overview layout with responsive cards and supporting UI patterns

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68da8786bc408328aefb9a6e495d62ce