### PR TITLE
Remove funnel card pseudo-element visuals

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -540,33 +540,6 @@ body {
   filter: drop-shadow(0 18px 30px rgba(107, 91, 255, 0.25));
 }
 
-.funnel-card::before,
-.funnel-card::after {
-  content: '';
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(90px);
-  opacity: 0.45;
-  pointer-events: none;
-  clip-path: inset(0 round var(--radius));
-}
-
-.funnel-card::before {
-  width: 320px;
-  height: 320px;
-  top: -160px;
-  left: -60px;
-  background: rgba(132, 112, 255, 0.3);
-}
-
-.funnel-card::after {
-  width: 360px;
-  height: 360px;
-  bottom: -180px;
-  right: -80px;
-  background: rgba(255, 177, 190, 0.3);
-}
-
 .funnel-card__header {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- remove the ::before/::after pseudo-element styling from funnel cards to eliminate the background glow on the Funnel Stages page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dabc8d5190832885ca339846dccc82