### PR TITLE
Adjust SEO funnel axis label positioning

### DIFF
--- a/src/components/SeoOpportunity.jsx
+++ b/src/components/SeoOpportunity.jsx
@@ -852,8 +852,8 @@ const SeoOpportunity = ({ rows }) => {
 
                   <text
                     className="seo-stacked-chart__axis-label"
-                    x={stackedChartLeft + stackedChartInnerWidth / 2}
-                    y={stackedChartHeight - 4}
+                    x="504"
+                    y="625"
                     textAnchor="middle"
                   >
                     Keyword categories


### PR DESCRIPTION
## Summary
- set the funnel stage distribution x-axis label to fixed coordinates
- ensure the axis label renders as "Keyword categories" at the requested position

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad71618ec83289e3a974080269db9